### PR TITLE
refactor: remove jsonref dependency from structured-output and simplify schema handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = []
 structured-output = [
     # python 3.15+ currently has no compatible pydantic release
     "pydantic>=2 ; python_version < '3.15'",
-    "jsonref>=1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ dev = [
     "pytest-cov>=7.0.0",
     "ruff>=0.14.13",
     "pydantic>=2 ; python_version < '3.15'",
-    "jsonref>=1.1.0",
 ]
 docs = [
     "furo>=2025.12.19",

--- a/src/acodex/_internal/output_type.py
+++ b/src/acodex/_internal/output_type.py
@@ -28,20 +28,6 @@ def _build_type_adapter(output_type: type[T]) -> TypeAdapter[T]:
     return cast("TypeAdapter[T]", type_adapter(type=output_type))
 
 
-def _replace_refs(schema: OutputSchemaInput) -> OutputSchemaInput:
-    try:
-        jsonref_module = importlib.import_module("jsonref")
-    except ModuleNotFoundError as error:
-        if error.name == "jsonref":
-            raise CodexStructuredResponseError(
-                "Structured output with `output_type` requires jsonref. "
-                'Install it with: pip install "acodex[structured-output]".',
-            ) from error
-        raise
-
-    return jsonref_module.replace_refs(schema, base_uri="", proxies=False)
-
-
 class OutputTypeAdapter(Generic[T]):
     def __init__(
         self,
@@ -66,7 +52,7 @@ class OutputTypeAdapter(Generic[T]):
         schema = self._adapter.json_schema()
         self._ensure_additional_properties_is_false(schema)
 
-        return _replace_refs(schema)
+        return schema
 
     def validate_json(self, json_string: str | bytes | bytearray) -> T:
         if self._adapter is not None:

--- a/src/acodex/_internal/output_type.py
+++ b/src/acodex/_internal/output_type.py
@@ -51,7 +51,6 @@ class OutputTypeAdapter(Generic[T]):
 
         schema = self._adapter.json_schema()
         self._ensure_additional_properties_is_false(schema)
-
         return schema
 
     def validate_json(self, json_string: str | bytes | bytearray) -> T:

--- a/tests/unit/internal/test_output_type.py
+++ b/tests/unit/internal/test_output_type.py
@@ -102,7 +102,7 @@ def test_json_schema_from_nested_output_type_sets_additional_properties_false_re
 
 
 @skip_output_type_tests_on_py315
-def test_json_schema_from_nested_output_type_replaces_refs() -> None:
+def test_json_schema_from_nested_output_type_preserves_refs() -> None:
     adapter: OutputTypeAdapter[_TypedCheckResult] = OutputTypeAdapter(
         output_type=_TypedCheckResult,
     )
@@ -110,8 +110,7 @@ def test_json_schema_from_nested_output_type_replaces_refs() -> None:
     schema = adapter.json_schema()
     assert schema is not None
 
-    for node in _iter_schema_nodes(schema):
-        assert "$ref" not in node
+    assert any("$ref" in node for node in _iter_schema_nodes(schema))
 
 
 @skip_output_type_tests_on_py315
@@ -269,48 +268,3 @@ def test_output_type_re_raises_non_pydantic_module_not_found(
         OutputTypeAdapter(output_type=_TypedPayload)
 
     assert error.value.name == "pydantic_core"
-
-
-@skip_output_type_tests_on_py315
-def test_json_schema_missing_jsonref_raises_structured_error_with_install_hint(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    real_import_module = importlib.import_module
-
-    def _import_module(name: str, package: str | None = None) -> object:
-        if name == "jsonref":
-            raise ModuleNotFoundError("No module named 'jsonref'", name="jsonref")
-        return real_import_module(name, package)
-
-    monkeypatch.setattr(output_type_module.importlib, "import_module", _import_module)
-    adapter: OutputTypeAdapter[_TypedPayload] = OutputTypeAdapter(output_type=_TypedPayload)
-
-    with pytest.raises(
-        CodexStructuredResponseError,
-        match='pip install "acodex\\[structured-output\\]"',
-    ) as error:
-        adapter.json_schema()
-
-    cause = error.value.__cause__
-    assert isinstance(cause, ModuleNotFoundError)
-    assert cause.name == "jsonref"
-
-
-@skip_output_type_tests_on_py315
-def test_json_schema_re_raises_non_jsonref_module_not_found(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    real_import_module = importlib.import_module
-
-    def _import_module(name: str, package: str | None = None) -> object:
-        if name == "jsonref":
-            raise ModuleNotFoundError("No module named 'jsonref'", name="some_other_dep")
-        return real_import_module(name, package)
-
-    monkeypatch.setattr(output_type_module.importlib, "import_module", _import_module)
-    adapter: OutputTypeAdapter[_TypedPayload] = OutputTypeAdapter(output_type=_TypedPayload)
-
-    with pytest.raises(ModuleNotFoundError) as error:
-        adapter.json_schema()
-
-    assert error.value.name == "some_other_dep"

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,6 @@ source = { editable = "." }
 
 [package.optional-dependencies]
 structured-output = [
-    { name = "jsonref" },
     { name = "pydantic", marker = "python_full_version < '3.15'" },
 ]
 
@@ -48,10 +47,7 @@ docs = [
 ]
 
 [package.metadata]
-requires-dist = [
-    { name = "jsonref", marker = "extra == 'structured-output'", specifier = ">=1" },
-    { name = "pydantic", marker = "python_full_version < '3.15' and extra == 'structured-output'", specifier = ">=2" },
-]
+requires-dist = [{ name = "pydantic", marker = "python_full_version < '3.15' and extra == 'structured-output'", specifier = ">=2" }]
 provides-extras = ["structured-output"]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -30,7 +30,6 @@ structured-output = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "jsonref" },
     { name = "mypy" },
     { name = "prek" },
     { name = "pydantic", marker = "python_full_version < '3.15'" },
@@ -52,7 +51,6 @@ provides-extras = ["structured-output"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "jsonref", specifier = ">=1.1.0" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "prek", specifier = ">=0.3.2" },
     { name = "pydantic", marker = "python_full_version < '3.15'", specifier = ">=2" },
@@ -423,15 +421,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
-name = "jsonref"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
 ]
 
 [[package]]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed an optional dependency from project configuration.

* **Refactor**
  * JSON schema generation now returns schemas with references preserved, eliminating prior automatic reference resolution.

* **Tests**
  * Updated unit tests to expect preserved $ref references; removed tests that asserted behavior related to the removed optional dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->