### PR TITLE
fix: handle oversized async stdout lines

### DIFF
--- a/src/acodex/_internal/process_runner.py
+++ b/src/acodex/_internal/process_runner.py
@@ -15,6 +15,7 @@ from acodex.exceptions import CodexCancelledError, CodexExecError
 
 _READ_POLL_INTERVAL_SECONDS: Final[float] = 0.05
 _PROCESS_TERMINATE_TIMEOUT_SECONDS: Final[float] = 1.0
+_ASYNC_STDOUT_READ_CHUNK_BYTES: Final[int] = 64 * 1024
 
 
 class _StdoutEofSentinel:
@@ -352,37 +353,55 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
         command: CodexExecCommand,
         stdout: asyncio.StreamReader,
     ) -> AsyncIterator[str]:
+        buffer = bytearray()
         while True:
             self._check_cancelled(command)
 
-            line = await self._read_next_line(command=command, stdout=stdout)
-            if line is _ASYNC_TIMEOUT:
+            buffered_line = self._pop_buffered_line(buffer)
+            if buffered_line is not None:
+                yield buffered_line.decode("utf-8", errors="replace").rstrip("\r\n")
                 continue
-            if line is _ASYNC_CANCELLED:
+
+            chunk = await self._read_next_chunk(command=command, stdout=stdout)
+            if chunk is _ASYNC_TIMEOUT:
+                continue
+            if chunk is _ASYNC_CANCELLED:
                 self._raise_cancelled()
-            if line == b"":
+            if chunk == b"":
+                if buffer:
+                    yield bytes(buffer).decode("utf-8", errors="replace").rstrip("\r\n")
                 return
 
-            yield cast("bytes", line).decode("utf-8", errors="replace").rstrip("\r\n")
+            buffer.extend(cast("bytes", chunk))
 
     @staticmethod
-    async def _read_next_line(
+    def _pop_buffered_line(buffer: bytearray) -> bytes | None:
+        newline_index = buffer.find(b"\n")
+        if newline_index == -1:
+            return None
+
+        line = bytes(buffer[: newline_index + 1])
+        del buffer[: newline_index + 1]
+        return line
+
+    @staticmethod
+    async def _read_next_chunk(
         *,
         command: CodexExecCommand,
         stdout: asyncio.StreamReader,
     ) -> _AsyncReadResult:
         signal = command.signal
         if isinstance(signal, asyncio.Event):
-            readline_task = asyncio.create_task(
-                stdout.readline(),
-                name="acodex-async-stdout-readline",
+            read_task = asyncio.create_task(
+                stdout.read(_ASYNC_STDOUT_READ_CHUNK_BYTES),
+                name="acodex-async-stdout-read",
             )
             cancelled_task = asyncio.create_task(
                 signal.wait(),
                 name="acodex-async-cancel-wait",
             )
             done, pending = await asyncio.wait(
-                {readline_task, cancelled_task},
+                {read_task, cancelled_task},
                 return_when=asyncio.FIRST_COMPLETED,
             )
             for task in pending:
@@ -393,11 +412,11 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
             if cancelled_task in done:
                 return _ASYNC_CANCELLED
 
-            return readline_task.result()
+            return read_task.result()
 
         try:
             return await asyncio.wait_for(
-                stdout.readline(),
+                stdout.read(_ASYNC_STDOUT_READ_CHUNK_BYTES),
                 timeout=_READ_POLL_INTERVAL_SECONDS,
             )
         except asyncio.TimeoutError:

--- a/tests/unit/internal/test_process_runner.py
+++ b/tests/unit/internal/test_process_runner.py
@@ -169,6 +169,32 @@ def test_async_stream_lines_yields_stdout_lines_without_newlines(tmp_path: Path)
     assert lines == ["first line", "second line", "third line"]
 
 
+def test_async_stream_lines_handles_oversized_stdout_lines(tmp_path: Path) -> None:
+    executable = _create_fake_codex_executable(tmp_path)
+    runner = AsyncCodexProcessRunner(executable_path=str(executable))
+    command = _build_command(mode="oversized_line")
+
+    async def run() -> list[str]:
+        return [line async for line in runner.stream_lines(command)]
+
+    lines = _run_async(run())
+
+    assert lines == ["x" * 70000, "tail"]
+
+
+def test_async_stream_lines_yields_final_line_without_trailing_newline(tmp_path: Path) -> None:
+    executable = _create_fake_codex_executable(tmp_path)
+    runner = AsyncCodexProcessRunner(executable_path=str(executable))
+    command = _build_command(mode="stdout_without_trailing_newline")
+
+    async def run() -> list[str]:
+        return [line async for line in runner.stream_lines(command)]
+
+    lines = _run_async(run())
+
+    assert lines == ["tail without newline"]
+
+
 def test_async_nonzero_exit_raises_codex_exec_error_includes_stderr(tmp_path: Path) -> None:
     executable = _create_fake_codex_executable(tmp_path)
     runner = AsyncCodexProcessRunner(executable_path=str(executable))
@@ -334,7 +360,7 @@ def test_async_stream_lines_create_task_failure_terminates_and_closes_stdin(
     assert stdin.close_called
 
 
-def test_async_cancel_during_readline_uses_async_event_wait_path(tmp_path: Path) -> None:
+def test_async_cancel_during_stdout_read_uses_async_event_wait_path(tmp_path: Path) -> None:
     executable = _create_fake_codex_executable(tmp_path)
     runner = AsyncCodexProcessRunner(executable_path=str(executable))
 
@@ -408,7 +434,7 @@ def test_async_cleanup_closes_stdin_and_cancels_stderr_task(
     assert stderr_task.cancelled()
 
 
-def test_async_read_next_line_returns_cancelled_when_signal_task_finishes_first() -> None:
+def test_async_read_next_chunk_returns_cancelled_when_signal_task_finishes_first() -> None:
     runner = AsyncCodexProcessRunner(executable_path="codex")
     signal = asyncio.Event()
     signal.set()
@@ -416,7 +442,7 @@ def test_async_read_next_line_returns_cancelled_when_signal_task_finishes_first(
     stdout = _ImmediateAsyncStdout()
 
     result = _run_async(
-        runner._read_next_line(command=command, stdout=cast("asyncio.StreamReader", stdout)),
+        runner._read_next_chunk(command=command, stdout=cast("asyncio.StreamReader", stdout)),
     )
 
     assert result is _ASYNC_CANCELLED
@@ -463,6 +489,16 @@ def _create_fake_codex_executable(tmp_path: Path) -> Path:
 
             if mode == "stdout_lines":
                 sys.stdout.write("first line\\r\\nsecond line\\nthird line\\r\\n")
+                sys.stdout.flush()
+                raise SystemExit(0)
+
+            if mode == "oversized_line":
+                sys.stdout.write("x" * 70000 + "\\n" + "tail\\n")
+                sys.stdout.flush()
+                raise SystemExit(0)
+
+            if mode == "stdout_without_trailing_newline":
+                sys.stdout.write("tail without newline")
                 sys.stdout.flush()
                 raise SystemExit(0)
 
@@ -583,23 +619,25 @@ class _FakeAsyncStdin:
 
 class _DelayedAsyncStdout:
     def __init__(self) -> None:
-        self._read_calls = 0
+        self._delay_done = False
+        self._chunks = [b"eventual ", b"line\n", b""]
+        self._chunk_index = 0
 
-    async def readline(self) -> bytes:
-        self._read_calls += 1
-        if self._read_calls == 1:
+    async def read(self, _: int = -1) -> bytes:
+        if not self._delay_done:
+            self._delay_done = True
             await asyncio.sleep(0.01)
-            return b"delayed line\n"
-        if self._read_calls == 2:
-            return b"eventual line\n"
-        return b""
+
+        chunk = self._chunks[self._chunk_index]
+        self._chunk_index += 1
+        return chunk
 
 
 class _ImmediateAsyncStdout:
     def __init__(self) -> None:
         self._read_calls = 0
 
-    async def readline(self) -> bytes:
+    async def read(self, _: int = -1) -> bytes:
         self._read_calls += 1
         return b"ready\n"
 
@@ -608,7 +646,7 @@ class _UnusedAsyncStdout:
     def __init__(self) -> None:
         self.read_calls = 0
 
-    async def readline(self) -> bytes:
+    async def read(self, _: int = -1) -> bytes:
         self.read_calls += 1
         return b""
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved stdout streaming to reliably handle large output lines.
  * Fixed handling of process output that doesn't include a trailing newline.

* **Tests**
  * Enhanced test coverage for edge cases in process output handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->