### PR TITLE
Fix async Codex stdout handling for oversized and unterminated lines

### DIFF
--- a/DIFFERENCES.md
+++ b/DIFFERENCES.md
@@ -14,6 +14,7 @@ intentional Python-specific adaptations.
 | return models are dataclasses | explicit value objects in Python | TS: `events.ts`, `items.ts`, `thread.ts`; Py: `src/acodex/types/*`; Tests: `tests/compatibility/test_ts_{events,items,thread_types}_compat.py` |
 | dual sync + async surfaces | common Python integration styles | Py: `src/acodex/{codex,thread}.py`; Tests: `tests/compatibility/test_ts_class_surface_compat.py` |
 | dedicated cancellation exception | clearer control flow | Py: `src/acodex/exceptions.py`; Tests: `tests/compatibility/test_ts_turn_options_compat.py`, `tests/unit/internal/test_process_runner.py` |
+| `CodexExecError` captures `stdout`/`stderr` | richer Python diagnostics for CLI failures | TS: `vendor/codex-ts-sdk/src/exec.ts`; Py: `src/acodex/exceptions.py`, `src/acodex/_internal/process_runner.py`; Tests: `tests/unit/internal/test_process_runner.py` |
 | CLI executable discovery via `PATH` | Python packaging constraints | TS: `codexOptions.ts`; Py: `src/acodex/exec.py`; Tests: `tests/compatibility/test_ts_codex_options_compat.py` |
 | narrower `output_schema` typing | stronger Python typing | TS: `turnOptions.ts`; Py: `src/acodex/types/turn_options.py`; Tests: `tests/compatibility/test_ts_turn_options_compat.py` |
 | streamed result exposes `streamed.result` | ergonomic post-stream access | Py: `src/acodex/types/turn.py`; Tests: `tests/compatibility/test_ts_thread_types_compat.py` |
@@ -208,7 +209,31 @@ Usage implication:
 
 - Ensure `codex` is installed and discoverable on `PATH`, or pass `codex_path_override`.
 
-## 8) Output schema typing is narrower in Python
+## 8) Exec failures expose captured process output in Python
+
+- TypeScript throws a generic `Error` string for CLI execution failures.
+- Python raises `CodexExecError` and stores captured `stdout` and `stderr` on the exception.
+
+References:
+
+- TS exec runner: `vendor/codex-ts-sdk/src/exec.ts`
+- Python exec exception: `src/acodex/exceptions.py`
+- Python process runners: `src/acodex/_internal/process_runner.py`
+- Tests: `tests/unit/internal/test_process_runner.py`
+
+Rationale:
+
+- Python callers often log or re-raise exceptions through frameworks that only preserve
+  `str(error)`. Including captured output directly in the exception message makes CLI failures much
+  easier to diagnose.
+- Keeping `stdout` and `stderr` as separate attributes still allows structured error handling.
+
+Usage implication:
+
+- Catch `CodexExecError` to inspect `error.stdout` and `error.stderr`, or rely on `str(error)` for a
+  combined diagnostic message.
+
+## 9) Output schema typing is narrower in Python
 
 - TypeScript: `TurnOptions.outputSchema?: unknown` (`vendor/codex-ts-sdk/src/turnOptions.ts`)
 - Python: `TurnOptions.output_schema: NotRequired[dict[str, JsonValue]]` (JSON-object shape),
@@ -224,7 +249,7 @@ Compatibility assertion:
 - Test: `tests/compatibility/test_ts_turn_options_compat.py` (accepts TS `unknown` as compatible with
   narrower Python typing)
 
-## 9) Streamed result exposes a completed turn property in Python
+## 10) Streamed result exposes a completed turn property in Python
 
 - TypeScript streamed flow returns events and leaves reduction to SDK internals in `run()`.
 - Python streamed result models expose `streamed.result` (sync and async) after the stream is fully
@@ -243,7 +268,7 @@ Usage implication:
 - Accessing `streamed.result` before full consumption raises
   `CodexThreadStreamNotConsumedError`.
 
-## 10) Python-only typed structured output (`output_type` + `structured_response`)
+## 11) Python-only typed structured output (`output_type` + `structured_response`)
 
 - TypeScript `Thread.run` / `runStreamed` expose `turnOptions.outputSchema` but do not expose a
   method-level typed output adapter argument.

--- a/docs/guides/troubleshooting.rst
+++ b/docs/guides/troubleshooting.rst
@@ -18,6 +18,15 @@ If you see ``CodexExecutableNotFoundError``:
 - Ensure the Codex CLI is installed and ``codex`` is on ``PATH``.
 - Or pass ``codex_path_override="/path/to/codex"`` to ``Codex(...)`` / ``AsyncCodex(...)``.
 
+Executable exits with a non-zero code
+-------------------------------------
+
+If you see ``CodexExecError``:
+
+- The exception message now includes captured ``STDOUT`` and ``STDERR`` sections when available.
+- You can also inspect ``error.stdout`` and ``error.stderr`` directly when logging or re-raising.
+- This is the fastest way to see why the underlying ``codex`` process failed.
+
 Structured output errors
 ------------------------
 

--- a/src/acodex/_internal/process_runner.py
+++ b/src/acodex/_internal/process_runner.py
@@ -5,6 +5,7 @@ import queue
 import subprocess  # noqa: S404
 import threading
 from abc import ABC, abstractmethod
+from collections import deque
 from collections.abc import AsyncIterator, Iterator
 from contextlib import suppress
 from dataclasses import dataclass
@@ -16,6 +17,9 @@ from acodex.exceptions import CodexCancelledError, CodexExecError
 _READ_POLL_INTERVAL_SECONDS: Final[float] = 0.05
 _PROCESS_TERMINATE_TIMEOUT_SECONDS: Final[float] = 1.0
 _ASYNC_STDOUT_READ_CHUNK_BYTES: Final[int] = 64 * 1024
+_STDERR_TAIL_CHUNK_COUNT: Final[int] = 256
+_SYNC_STDERR_READ_CHUNK_CHARS: Final[int] = 4 * 1024
+_ASYNC_STDERR_READ_CHUNK_BYTES: Final[int] = 4 * 1024
 
 
 class _StdoutEofSentinel:
@@ -36,6 +40,8 @@ _ASYNC_CANCELLED: Final[_AsyncCancelledSentinel] = _AsyncCancelledSentinel()
 
 _StdoutQueueItem: TypeAlias = str | _StdoutEofSentinel
 _AsyncReadResult: TypeAlias = bytes | _AsyncTimeoutSentinel | _AsyncCancelledSentinel
+_SyncOutputTailChunks: TypeAlias = deque[str]
+_AsyncOutputTailChunks: TypeAlias = deque[bytes]
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,6 +75,22 @@ class CodexProcessRunnerBase(ABC):
         self._executable_path: Final[str] = executable_path
 
     @staticmethod
+    def _new_sync_output_tail_chunks() -> _SyncOutputTailChunks:
+        return deque(maxlen=_STDERR_TAIL_CHUNK_COUNT)
+
+    @staticmethod
+    def _join_sync_output_tail_chunks(chunks: _SyncOutputTailChunks) -> str:
+        return "".join(chunks)
+
+    @staticmethod
+    def _new_async_output_tail_chunks() -> _AsyncOutputTailChunks:
+        return deque(maxlen=_STDERR_TAIL_CHUNK_COUNT)
+
+    @staticmethod
+    def _join_async_output_tail_chunks(chunks: _AsyncOutputTailChunks) -> str:
+        return b"".join(chunks).decode("utf-8", errors="replace")
+
+    @staticmethod
     def _check_cancelled(command: CodexExecCommand) -> None:
         signal = command.signal
         if signal is None:
@@ -98,8 +120,8 @@ class SyncCodexProcessRunner(CodexProcessRunnerBase):
         stdio = self._require_stdio(process)
 
         stdout_queue: queue.Queue[_StdoutQueueItem] = queue.Queue()
-        stdout_chunks: list[str] = []
-        stderr_chunks: list[str] = []
+        stdout_chunks = self._new_sync_output_tail_chunks()
+        stderr_chunks = self._new_sync_output_tail_chunks()
         reader_threads = self._start_reader_threads(
             stdout=stdio.stdout,
             stderr=stdio.stderr,
@@ -126,13 +148,12 @@ class SyncCodexProcessRunner(CodexProcessRunnerBase):
             return_code = process.wait()
             reader_threads.stdout_thread.join()
             reader_threads.stderr_thread.join()
-            stdout_text = "".join(stdout_chunks)
-            stderr_text = "".join(stderr_chunks)
-            self._raise_on_bad_exit(
-                return_code=return_code,
-                stdout=stdout_text,
-                stderr=stderr_text,
-            )
+            stdout_text = ""
+            stderr_text = ""
+            if return_code != 0:
+                stdout_text = self._join_sync_output_tail_chunks(stdout_chunks)
+                stderr_text = self._join_sync_output_tail_chunks(stderr_chunks)
+            self._raise_on_bad_exit(return_code=return_code, stdout=stdout_text, stderr=stderr_text)
         except CodexCancelledError:
             self._terminate_process(process)
             raise
@@ -175,8 +196,8 @@ class SyncCodexProcessRunner(CodexProcessRunnerBase):
         stdout: IO[str],
         stderr: IO[str],
         stdout_queue: queue.Queue[_StdoutQueueItem],
-        stdout_chunks: list[str],
-        stderr_chunks: list[str],
+        stdout_chunks: _SyncOutputTailChunks,
+        stderr_chunks: _SyncOutputTailChunks,
     ) -> _SyncReaderThreads:
         stdout_thread = threading.Thread(
             target=self._pump_stdout,
@@ -250,7 +271,7 @@ class SyncCodexProcessRunner(CodexProcessRunnerBase):
         stream: IO[str],
         *,
         output: queue.Queue[_StdoutQueueItem],
-        chunks: list[str],
+        chunks: _SyncOutputTailChunks,
     ) -> None:
         try:
             for line in stream:
@@ -260,8 +281,12 @@ class SyncCodexProcessRunner(CodexProcessRunnerBase):
             output.put(_STDOUT_EOF)
 
     @staticmethod
-    def _pump_stderr(stream: IO[str], chunks: list[str]) -> None:
-        chunks.append(stream.read())
+    def _pump_stderr(stream: IO[str], chunks: _SyncOutputTailChunks) -> None:
+        while True:
+            chunk = stream.read(_SYNC_STDERR_READ_CHUNK_CHARS)
+            if not chunk:
+                return
+            chunks.append(chunk)
 
     @staticmethod
     def _terminate_process(process: subprocess.Popen[str]) -> None:
@@ -289,15 +314,17 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
 
         process = await self._spawn_process(command)
         stdio: _AsyncStdio | None = None
-        stderr_task: asyncio.Task[bytes] | None = None
-        stdout_chunks: list[bytes] = []
+        stdout_chunks = self._new_async_output_tail_chunks()
+        stderr_chunks = self._new_async_output_tail_chunks()
+        cleanup_stderr_task: asyncio.Task[None] | None = None
 
         try:
             stdio = self._require_stdio(process)
             stderr_task = asyncio.create_task(
-                stdio.stderr.read(),
+                self._capture_stderr_tail(stderr=stdio.stderr, chunks=stderr_chunks),
                 name="acodex-async-stderr-reader",
             )
+            cleanup_stderr_task = stderr_task
 
             await self._write_stdin(stdin=stdio.stdin, stdin_text=command.stdin)
             async for line in self._iter_stdout_lines(
@@ -308,8 +335,12 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
                 yield line
 
             return_code = await process.wait()
-            stdout_text = b"".join(stdout_chunks).decode("utf-8", errors="replace")
-            stderr_text = await self._decode_stderr(stderr_task)
+            stdout_text = ""
+            stderr_text = ""
+            if return_code != 0:
+                await stderr_task
+                stdout_text = self._join_async_output_tail_chunks(stdout_chunks)
+                stderr_text = self._join_async_output_tail_chunks(stderr_chunks)
 
             self._raise_on_bad_exit(
                 return_code=return_code,
@@ -323,7 +354,7 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
             await self._cleanup(
                 process=process,
                 stdin=stdio.stdin if stdio is not None else None,
-                stderr_task=stderr_task,
+                stderr_task=cleanup_stderr_task,
             )
 
     async def _spawn_process(self, command: CodexExecCommand) -> asyncio.subprocess.Process:
@@ -344,7 +375,7 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
         *,
         process: asyncio.subprocess.Process,
         stdin: asyncio.StreamWriter | None,
-        stderr_task: asyncio.Task[bytes] | None,
+        stderr_task: asyncio.Task[None] | None,
     ) -> None:
         await self._terminate_process(process)
 
@@ -390,7 +421,7 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
         *,
         command: CodexExecCommand,
         stdout: asyncio.StreamReader,
-        stdout_chunks: list[bytes],
+        stdout_chunks: _AsyncOutputTailChunks | None = None,
     ) -> AsyncIterator[str]:
         buffer = bytearray()
         while True:
@@ -412,8 +443,21 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
                 return
 
             chunk_bytes = cast("bytes", chunk)
-            stdout_chunks.append(chunk_bytes)
+            if stdout_chunks is not None:
+                stdout_chunks.append(chunk_bytes)
             buffer.extend(chunk_bytes)
+
+    @staticmethod
+    async def _capture_stderr_tail(
+        *,
+        stderr: asyncio.StreamReader,
+        chunks: _AsyncOutputTailChunks,
+    ) -> None:
+        while True:
+            chunk = await stderr.read(_ASYNC_STDERR_READ_CHUNK_BYTES)
+            if not chunk:
+                return
+            chunks.append(chunk)
 
     @staticmethod
     def _pop_buffered_line(buffer: bytearray) -> bytes | None:
@@ -471,10 +515,6 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
     def _raise_on_bad_exit(cls, *, return_code: int, stdout: str, stderr: str) -> None:
         if return_code != 0:
             cls._raise_exec_error(detail=f"code {return_code}", stdout=stdout, stderr=stderr)
-
-    @staticmethod
-    async def _decode_stderr(stderr_task: asyncio.Task[bytes]) -> str:
-        return (await stderr_task).decode("utf-8", errors="replace")
 
     @staticmethod
     async def _terminate_process(process: asyncio.subprocess.Process) -> None:

--- a/src/acodex/_internal/process_runner.py
+++ b/src/acodex/_internal/process_runner.py
@@ -77,8 +77,12 @@ class CodexProcessRunnerBase(ABC):
             raise CodexCancelledError("Turn cancelled")
 
     @staticmethod
-    def _raise_exec_error(*, detail: str, stderr: str) -> NoReturn:
-        raise CodexExecError(f"Codex Exec exited with {detail}", stderr=stderr)
+    def _raise_exec_error(*, detail: str, stdout: str, stderr: str) -> NoReturn:
+        raise CodexExecError(
+            f"Codex Exec exited with {detail}",
+            stdout=stdout,
+            stderr=stderr,
+        )
 
     @abstractmethod
     def stream_lines(self, command: CodexExecCommand) -> Iterator[str] | AsyncIterator[str]:
@@ -93,11 +97,13 @@ class SyncCodexProcessRunner(CodexProcessRunnerBase):
         stdio = self._require_stdio(process)
 
         stdout_queue: queue.Queue[_StdoutQueueItem] = queue.Queue()
+        stdout_chunks: list[str] = []
         stderr_chunks: list[str] = []
         reader_threads = self._start_reader_threads(
             stdout=stdio.stdout,
             stderr=stdio.stderr,
             stdout_queue=stdout_queue,
+            stdout_chunks=stdout_chunks,
             stderr_chunks=stderr_chunks,
         )
         resources = _SyncResources(
@@ -117,9 +123,15 @@ class SyncCodexProcessRunner(CodexProcessRunnerBase):
                 stdout_thread=reader_threads.stdout_thread,
             )
             return_code = process.wait()
+            reader_threads.stdout_thread.join()
             reader_threads.stderr_thread.join()
+            stdout_text = "".join(stdout_chunks)
             stderr_text = "".join(stderr_chunks)
-            self._raise_on_bad_exit(return_code=return_code, stderr=stderr_text)
+            self._raise_on_bad_exit(
+                return_code=return_code,
+                stdout=stdout_text,
+                stderr=stderr_text,
+            )
         except CodexCancelledError:
             self._terminate_process(process)
             raise
@@ -140,7 +152,7 @@ class SyncCodexProcessRunner(CodexProcessRunnerBase):
                 bufsize=1,
             )
         except OSError as error:
-            self._raise_exec_error(detail=f"spawn failure: {error}", stderr="")
+            self._raise_exec_error(detail=f"spawn failure: {error}", stdout="", stderr="")
 
     def _require_stdio(self, process: subprocess.Popen[str]) -> _SyncStdio:
         stdin = process.stdin
@@ -148,7 +160,11 @@ class SyncCodexProcessRunner(CodexProcessRunnerBase):
         stderr = process.stderr
         if stdin is None or stdout is None or stderr is None:
             self._terminate_process(process)
-            self._raise_exec_error(detail="spawn failure: missing stdio streams", stderr="")
+            self._raise_exec_error(
+                detail="spawn failure: missing stdio streams",
+                stdout="",
+                stderr="",
+            )
 
         return _SyncStdio(stdin=stdin, stdout=stdout, stderr=stderr)
 
@@ -158,11 +174,16 @@ class SyncCodexProcessRunner(CodexProcessRunnerBase):
         stdout: IO[str],
         stderr: IO[str],
         stdout_queue: queue.Queue[_StdoutQueueItem],
+        stdout_chunks: list[str],
         stderr_chunks: list[str],
     ) -> _SyncReaderThreads:
         stdout_thread = threading.Thread(
             target=self._pump_stdout,
-            args=(stdout, stdout_queue),
+            args=(stdout,),
+            kwargs={
+                "output": stdout_queue,
+                "chunks": stdout_chunks,
+            },
             name="acodex-sync-stdout-reader",
             daemon=True,
         )
@@ -208,9 +229,9 @@ class SyncCodexProcessRunner(CodexProcessRunnerBase):
             yield cast("str", item).rstrip("\r\n")
 
     @classmethod
-    def _raise_on_bad_exit(cls, *, return_code: int, stderr: str) -> None:
+    def _raise_on_bad_exit(cls, *, return_code: int, stdout: str, stderr: str) -> None:
         if return_code != 0:
-            cls._raise_exec_error(detail=f"code {return_code}", stderr=stderr)
+            cls._raise_exec_error(detail=f"code {return_code}", stdout=stdout, stderr=stderr)
 
     def _cleanup(self, *, process: subprocess.Popen[str], resources: _SyncResources) -> None:
         self._terminate_process(process)
@@ -224,9 +245,15 @@ class SyncCodexProcessRunner(CodexProcessRunnerBase):
         resources.stderr_thread.join()
 
     @staticmethod
-    def _pump_stdout(stream: IO[str], output: queue.Queue[_StdoutQueueItem]) -> None:
+    def _pump_stdout(
+        stream: IO[str],
+        *,
+        output: queue.Queue[_StdoutQueueItem],
+        chunks: list[str],
+    ) -> None:
         try:
             for line in stream:
+                chunks.append(line)
                 output.put(line)
         finally:
             output.put(_STDOUT_EOF)
@@ -262,6 +289,7 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
         process = await self._spawn_process(command)
         stdio: _AsyncStdio | None = None
         stderr_task: asyncio.Task[bytes] | None = None
+        stdout_chunks: list[str] = []
 
         try:
             stdio = self._require_stdio(process)
@@ -271,13 +299,22 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
             )
 
             await self._write_stdin(stdin=stdio.stdin, stdin_text=command.stdin)
-            async for line in self._iter_stdout_lines(command=command, stdout=stdio.stdout):
+            async for line in self._iter_stdout_lines(
+                command=command,
+                stdout=stdio.stdout,
+                stdout_chunks=stdout_chunks,
+            ):
                 yield line
 
             return_code = await process.wait()
+            stdout_text = "".join(stdout_chunks)
             stderr_text = await self._decode_stderr(stderr_task)
 
-            self._raise_on_bad_exit(return_code=return_code, stderr=stderr_text)
+            self._raise_on_bad_exit(
+                return_code=return_code,
+                stdout=stdout_text,
+                stderr=stderr_text,
+            )
         except CodexCancelledError:
             await self._terminate_process(process)
             raise
@@ -299,7 +336,7 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
                 stderr=subprocess.PIPE,
             )
         except OSError as error:
-            self._raise_exec_error(detail=f"spawn failure: {error}", stderr="")
+            self._raise_exec_error(detail=f"spawn failure: {error}", stdout="", stderr="")
 
     async def _cleanup(
         self,
@@ -332,6 +369,7 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
         if stdin is None or stdout is None or stderr is None:
             raise CodexExecError(
                 "Codex Exec exited with spawn failure: missing stdio streams",
+                stdout="",
                 stderr="",
             )
 
@@ -351,6 +389,7 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
         *,
         command: CodexExecCommand,
         stdout: asyncio.StreamReader,
+        stdout_chunks: list[str],
     ) -> AsyncIterator[str]:
         while True:
             self._check_cancelled(command)
@@ -363,7 +402,9 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
             if line == b"":
                 return
 
-            yield cast("bytes", line).decode("utf-8", errors="replace").rstrip("\r\n")
+            decoded_line = cast("bytes", line).decode("utf-8", errors="replace")
+            stdout_chunks.append(decoded_line)
+            yield decoded_line.rstrip("\r\n")
 
     @staticmethod
     async def _read_next_line(
@@ -408,9 +449,9 @@ class AsyncCodexProcessRunner(CodexProcessRunnerBase):
         raise CodexCancelledError("Turn cancelled")
 
     @classmethod
-    def _raise_on_bad_exit(cls, *, return_code: int, stderr: str) -> None:
+    def _raise_on_bad_exit(cls, *, return_code: int, stdout: str, stderr: str) -> None:
         if return_code != 0:
-            cls._raise_exec_error(detail=f"code {return_code}", stderr=stderr)
+            cls._raise_exec_error(detail=f"code {return_code}", stdout=stdout, stderr=stderr)
 
     @staticmethod
     async def _decode_stderr(stderr_task: asyncio.Task[bytes]) -> str:

--- a/src/acodex/exceptions.py
+++ b/src/acodex/exceptions.py
@@ -10,10 +10,20 @@ class CodexCancelledError(CodexError):
 
 
 class CodexExecError(CodexError):
-    """Raised when the codex executable fails to start or exits unsuccessfully."""
+    """Raised when the codex executable fails to start or exits unsuccessfully.
 
-    def __init__(self, message: str, *, stderr: str | None = None) -> None:
-        super().__init__(message)
+    Captured process output is available on ``stdout`` and ``stderr`` when present.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        stdout: str | None = None,
+        stderr: str | None = None,
+    ) -> None:
+        super().__init__(_format_exec_error_message(message, stdout=stdout, stderr=stderr))
+        self.stdout = stdout
         self.stderr = stderr
 
 
@@ -52,3 +62,33 @@ class CodexOutputSchemaError(CodexError):
 
 class CodexInternalError(CodexError):
     """Raised when an internal invariant is violated, indicating a bug in acodex."""
+
+
+def _format_exec_error_message(
+    message: str,
+    *,
+    stdout: str | None,
+    stderr: str | None,
+) -> str:
+    sections = [message]
+
+    normalized_stdout = _normalize_exec_output(stdout)
+    if normalized_stdout is not None:
+        sections.extend(("", "STDOUT:", normalized_stdout))
+
+    normalized_stderr = _normalize_exec_output(stderr)
+    if normalized_stderr is not None:
+        sections.extend(("", "STDERR:", normalized_stderr))
+
+    return "\n".join(sections)
+
+
+def _normalize_exec_output(output: str | None) -> str | None:
+    if output is None:
+        return None
+
+    normalized_output = output.rstrip("\r\n")
+    if not normalized_output:
+        return None
+
+    return normalized_output

--- a/tests/unit/internal/test_process_runner.py
+++ b/tests/unit/internal/test_process_runner.py
@@ -43,7 +43,9 @@ def test_sync_nonzero_exit_raises_codex_exec_error_includes_stderr(tmp_path: Pat
     with pytest.raises(CodexExecError, match=re.escape("Codex Exec exited with code 7")) as error:
         list(runner.stream_lines(command))
 
+    assert not error.value.stdout
     assert error.value.stderr == "stderr boom\n"
+    assert str(error.value) == "Codex Exec exited with code 7\n\nSTDERR:\nstderr boom"
 
 
 def test_sync_nonzero_exit_before_stdout_closes_raises_codex_exec_error(tmp_path: Path) -> None:
@@ -54,7 +56,11 @@ def test_sync_nonzero_exit_before_stdout_closes_raises_codex_exec_error(tmp_path
     with pytest.raises(CodexExecError, match=re.escape("Codex Exec exited with code 7")) as error:
         list(runner.stream_lines(command))
 
+    assert error.value.stdout == "late line\n"
     assert error.value.stderr == "stderr boom\n"
+    assert str(error.value) == (
+        "Codex Exec exited with code 7\n\nSTDOUT:\nlate line\n\nSTDERR:\nstderr boom"
+    )
 
 
 def test_sync_cancel_pre_set_raises_cancelled_without_spawning(tmp_path: Path) -> None:
@@ -181,7 +187,9 @@ def test_async_nonzero_exit_raises_codex_exec_error_includes_stderr(tmp_path: Pa
     with pytest.raises(CodexExecError, match=re.escape("Codex Exec exited with code 7")) as error:
         _run_async(run())
 
+    assert not error.value.stdout
     assert error.value.stderr == "stderr boom\n"
+    assert str(error.value) == "Codex Exec exited with code 7\n\nSTDERR:\nstderr boom"
 
 
 def test_async_nonzero_exit_before_stdout_closes_raises_codex_exec_error(tmp_path: Path) -> None:
@@ -196,7 +204,11 @@ def test_async_nonzero_exit_before_stdout_closes_raises_codex_exec_error(tmp_pat
     with pytest.raises(CodexExecError, match=re.escape("Codex Exec exited with code 7")) as error:
         _run_async(asyncio.wait_for(run(), timeout=2.0))
 
+    assert error.value.stdout == "late line\n"
     assert error.value.stderr == "stderr boom\n"
+    assert str(error.value) == (
+        "Codex Exec exited with code 7\n\nSTDOUT:\nlate line\n\nSTDERR:\nstderr boom"
+    )
 
 
 def test_async_cancel_pre_set_raises_cancelled_without_spawning(tmp_path: Path) -> None:
@@ -372,6 +384,7 @@ def test_async_read_timeout_path_returns_timeout_then_eventually_yields(
             async for line in runner._iter_stdout_lines(
                 command=command,
                 stdout=cast("asyncio.StreamReader", stdout),
+                stdout_chunks=[],
             )
         ]
 

--- a/tests/unit/internal/test_process_runner.py
+++ b/tests/unit/internal/test_process_runner.py
@@ -7,10 +7,11 @@ import re
 import subprocess  # noqa: S404
 import sys
 import threading
+from collections import deque
 from collections.abc import Coroutine
 from pathlib import Path
 from textwrap import dedent
-from typing import Any, TypeVar, cast
+from typing import IO, Any, TypeVar, cast
 
 import pytest
 
@@ -29,6 +30,24 @@ def test_sync_stream_lines_yields_stdout_lines_without_newlines(tmp_path: Path) 
     executable = _create_fake_codex_executable(tmp_path)
     runner = SyncCodexProcessRunner(executable_path=str(executable))
     command = _build_command(mode="stdout_lines")
+
+    lines = list(runner.stream_lines(command))
+
+    assert lines == ["first line", "second line", "third line"]
+
+
+def test_sync_stream_lines_success_does_not_join_stderr_tail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    executable = _create_fake_codex_executable(tmp_path)
+    runner = SyncCodexProcessRunner(executable_path=str(executable))
+    command = _build_command(mode="stdout_lines")
+
+    def fail_join(_: object) -> str:
+        raise AssertionError("stderr tail should not be joined on success")
+
+    monkeypatch.setattr(runner, "_join_sync_output_tail_chunks", fail_join)
 
     lines = list(runner.stream_lines(command))
 
@@ -162,10 +181,42 @@ def test_sync_terminate_process_falls_back_to_kill_after_timeouts() -> None:
     assert process.kill_called
 
 
+def test_sync_pump_stderr_keeps_only_tail_chunks() -> None:
+    chunks: deque[str] = deque(maxlen=2)
+
+    SyncCodexProcessRunner._pump_stderr(
+        cast("IO[str]", _ChunkedSyncStderr(["first", "second", "third"])),
+        chunks,
+    )
+
+    assert list(chunks) == ["second", "third"]
+
+
 def test_async_stream_lines_yields_stdout_lines_without_newlines(tmp_path: Path) -> None:
     executable = _create_fake_codex_executable(tmp_path)
     runner = AsyncCodexProcessRunner(executable_path=str(executable))
     command = _build_command(mode="stdout_lines")
+
+    async def run() -> list[str]:
+        return [line async for line in runner.stream_lines(command)]
+
+    lines = _run_async(run())
+
+    assert lines == ["first line", "second line", "third line"]
+
+
+def test_async_stream_lines_success_does_not_join_stderr_tail(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    executable = _create_fake_codex_executable(tmp_path)
+    runner = AsyncCodexProcessRunner(executable_path=str(executable))
+    command = _build_command(mode="stdout_lines")
+
+    def fail_join(_: object) -> str:
+        raise AssertionError("stderr tail should not be joined on success")
+
+    monkeypatch.setattr(runner, "_join_async_output_tail_chunks", fail_join)
 
     async def run() -> list[str]:
         return [line async for line in runner.stream_lines(command)]
@@ -410,7 +461,6 @@ def test_async_read_timeout_path_returns_timeout_then_eventually_yields(
             async for line in runner._iter_stdout_lines(
                 command=command,
                 stdout=cast("asyncio.StreamReader", stdout),
-                stdout_chunks=[],
             )
         ]
 
@@ -425,14 +475,14 @@ def test_async_cleanup_closes_stdin_and_cancels_stderr_task(
 ) -> None:
     runner = AsyncCodexProcessRunner(executable_path="codex")
     stdin = _FakeAsyncStdin()
-    stderr_task: asyncio.Task[bytes] | None = None
+    stderr_task: asyncio.Task[None] | None = None
 
     async def fake_terminate(_: object) -> None:
         await asyncio.sleep(0)
 
     async def run() -> None:
         nonlocal stderr_task
-        stderr_task = asyncio.create_task(asyncio.sleep(10.0, result=b"stderr"))
+        stderr_task = asyncio.create_task(asyncio.sleep(10.0))
         monkeypatch.setattr(runner, "_terminate_process", fake_terminate)
         await runner._cleanup(
             process=cast("asyncio.subprocess.Process", _FakeAsyncProcess()),
@@ -459,6 +509,22 @@ def test_async_read_next_chunk_returns_cancelled_when_signal_task_finishes_first
     )
 
     assert result is _ASYNC_CANCELLED
+
+
+def test_async_capture_stderr_tail_keeps_only_tail_chunks() -> None:
+    chunks: deque[bytes] = deque(maxlen=2)
+
+    _run_async(
+        AsyncCodexProcessRunner._capture_stderr_tail(
+            stderr=cast(
+                "asyncio.StreamReader",
+                _ChunkedAsyncStderr([b"first", b"second", b"third"]),
+            ),
+            chunks=chunks,
+        ),
+    )
+
+    assert list(chunks) == [b"second", b"third"]
 
 
 def _build_command(
@@ -599,6 +665,17 @@ class _KillFallbackSyncProcess:
         self.kill_called = True
 
 
+class _ChunkedSyncStderr:
+    def __init__(self, chunks: list[str]) -> None:
+        self._chunks = [*chunks, ""]
+        self._chunk_index = 0
+
+    def read(self, _: int = -1) -> str:
+        chunk = self._chunks[self._chunk_index]
+        self._chunk_index += 1
+        return chunk
+
+
 class _MissingAsyncStdioProcess:
     stdin: None = None
     stdout: None = None
@@ -653,6 +730,17 @@ class _ImmediateAsyncStdout:
     async def read(self, _: int = -1) -> bytes:
         self._read_calls += 1
         return b"ready\n"
+
+
+class _ChunkedAsyncStderr:
+    def __init__(self, chunks: list[bytes]) -> None:
+        self._chunks = [*chunks, b""]
+        self._chunk_index = 0
+
+    async def read(self, _: int = -1) -> bytes:
+        chunk = self._chunks[self._chunk_index]
+        self._chunk_index += 1
+        return chunk
 
 
 class _UnusedAsyncStdout:


### PR DESCRIPTION
## Summary
- Read async stdout in fixed-size chunks instead of `readline()` to avoid failures on oversized output lines
- Buffer partial chunks and emit complete lines correctly, including a final line without a trailing newline
- Update async runner tests and fake process fixtures to cover oversized output, unterminated final output, and renamed read-path helpers

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Process execution failures now expose captured `stdout` and `stderr` output in error details for enhanced debugging.

* **Documentation**
  * Added troubleshooting guide for handling executable exit failures and inspecting error output.
  * Updated SDK differences documentation with Python-specific process error handling information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->