### PR TITLE
tests: add opt-in real SDK integration suite

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,11 +46,11 @@ jobs:
 
       - name: Run tests with coverage
         if: ${{ !startsWith(matrix.python-version, '3.15') }}
-        run: uv run pytest tests/ --cov=src/acodex --cov-report=xml --cov-report=term-missing
+        run: uv run pytest -m "not real_integration" tests/ --cov=src/acodex --cov-report=xml --cov-report=term-missing
 
       - name: Run tests (no coverage gate on Python 3.15)
         if: ${{ startsWith(matrix.python-version, '3.15') }}
-        run: uv run pytest tests/ --cov=src/acodex --cov-report=xml --cov-report=term-missing --cov-fail-under=0
+        run: uv run pytest -m "not real_integration" tests/ --cov=src/acodex --cov-report=xml --cov-report=term-missing --cov-fail-under=0
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.14'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,8 @@ testing standards. Prefer uv for all tooling.
 - Install deps (dev): `uv sync --group dev`
 - Format: `make format`
 - Lint (all): `make lint`
-- Test (all): `make test`
+- Test (CI-safe default): `make test`
+- Test (real Codex integration, opt-in): `ACODEX_RUN_REAL_INTEGRATION=1 make test-real-integration`
 
 ## Build
 
@@ -25,12 +26,15 @@ testing standards. Prefer uv for all tooling.
 
 ## Tests
 
-- Run all tests (coverage): `make test`
+- Run the default CI-safe test suite (coverage): `make test`
+- Run the paid real Codex integration suite locally: `ACODEX_RUN_REAL_INTEGRATION=1 make test-real-integration`
 - Run a single test file: `uv run pytest tests/test_some.py`
 - Run a single test: `uv run pytest tests/test_some.:test_some`
 - Run tests with keyword filter: `uv run pytest -k "dependency" tests/`
 - Coverage (recommended for new work):
   `uv run pytest tests/ --cov=src/acodex --cov-report=term-missing`
+- Real integration tests are excluded from `make test` and all GitHub CI runs.
+- `ACODEX_REAL_MODEL` defaults to `gpt-5.3-codex` and can be overridden for local runs.
 
 ## Repo structure
 
@@ -92,6 +96,8 @@ testing standards. Prefer uv for all tooling.
 - Always ensure linting and type-checking run clean with no errors.
 - Every new change must preserve 100% test coverage.
 - After making changes, always run `make lint` and `make test` and report results.
+- For SDK integration changes, also run `ACODEX_RUN_REAL_INTEGRATION=1 make test-real-integration`
+  locally when a live Codex setup is available.
 
 ## Ruff configuration highlights
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,17 @@ Tests (coverage must stay at 100%):
 make test
 ```
 
+`make test` is CI-safe and excludes the paid opt-in real Codex integration suite.
+
+Run the real SDK integration suite locally only when you explicitly want to exercise a live Codex
+setup:
+
+```bash
+ACODEX_RUN_REAL_INTEGRATION=1 make test-real-integration
+```
+
+`ACODEX_REAL_MODEL` defaults to `gpt-5.3-codex` and can be overridden for local runs.
+
 Docs:
 
 ```bash

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: format lint test docs vendor-ts-sdk vendor-ts-sdk-latest
+.PHONY: format lint test test-real-integration docs vendor-ts-sdk vendor-ts-sdk-latest
 
 format:
 	uv run ruff format .
@@ -10,7 +10,10 @@ lint:
 	uv run mypy .
 
 test:
-	uv run pytest tests/ --cov=src/acodex --cov-report=term-missing
+	uv run pytest -m "not real_integration" tests/ --cov=src/acodex --cov-report=term-missing
+
+test-real-integration:
+	ACODEX_RUN_REAL_INTEGRATION=1 uv run pytest -m "real_integration" tests/integration/
 
 docs:
 	rm -rf docs/_build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,9 @@ addopts = [
     "--strict-markers",
     "--strict-config",
 ]
+markers = [
+    "real_integration: opt-in tests that exercise a live local Codex CLI setup",
+]
 filterwarnings = [
     "error",
     # Ignore ResourceWarnings from unclosed sockets/event loops during GC

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from shutil import which
+from typing import Final
+
+import pytest
+
+RUN_REAL_INTEGRATION_ENV: Final[str] = "ACODEX_RUN_REAL_INTEGRATION"
+REAL_MODEL_ENV: Final[str] = "ACODEX_REAL_MODEL"
+DEFAULT_REAL_MODEL: Final[str] = "gpt-5.3-codex"
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    del config
+
+    run_enabled = os.getenv(RUN_REAL_INTEGRATION_ENV) == "1"
+    codex_path = which("codex")
+
+    for item in items:
+        if "real_integration" not in item.keywords:
+            continue
+
+        if not run_enabled:
+            item.add_marker(
+                pytest.mark.skip(
+                    reason=(
+                        f"Set {RUN_REAL_INTEGRATION_ENV}=1 to run real Codex integration tests."
+                    ),
+                ),
+            )
+            continue
+
+        if codex_path is None:
+            item.add_marker(
+                pytest.mark.skip(
+                    reason="Real integration tests require `codex` to be available on PATH.",
+                ),
+            )
+
+
+@pytest.fixture(scope="session")
+def codex_path() -> str:
+    path = which("codex")
+    if path is None:
+        pytest.skip("Real integration tests require `codex` to be available on PATH.")
+    return path
+
+
+@pytest.fixture(scope="session")
+def real_model() -> str:
+    return os.getenv(REAL_MODEL_ENV) or DEFAULT_REAL_MODEL
+
+
+@pytest.fixture()
+def real_working_directory(tmp_path: Path) -> Path:
+    workdir = tmp_path / "workspace"
+    workdir.mkdir()
+    (workdir / "README.txt").write_text("real integration workspace\n", encoding="utf-8")
+    return workdir

--- a/tests/integration/test_real_sdk.py
+++ b/tests/integration/test_real_sdk.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from acodex import (
+    AsyncCodex,
+    Codex,
+    ItemCompletedEvent,
+    ThreadOptions,
+    ThreadStartedEvent,
+    TurnCompletedEvent,
+    TurnStartedEvent,
+)
+
+pytestmark = pytest.mark.real_integration
+
+
+def test_codex_start_thread_run_returns_expected_plain_response(
+    real_model: str,
+    real_working_directory: Path,
+) -> None:
+    response_marker = "ACODEX_SYNC_PLAIN_OK"
+    client = Codex()
+    thread = client.start_thread(**_build_thread_options(real_model, real_working_directory))
+
+    turn = thread.run(
+        f"Do not use tools. Reply with exactly {response_marker} and nothing else.",
+    )
+
+    assert thread.id is not None
+    assert turn.items
+    assert turn.final_response.strip() == response_marker
+
+
+def test_codex_resume_thread_preserves_context_across_turns(
+    real_model: str,
+    real_working_directory: Path,
+) -> None:
+    remembered_value = "ACODEX_RESUME_VALUE_7319"
+    client = Codex()
+    thread = client.start_thread(**_build_thread_options(real_model, real_working_directory))
+
+    first_turn = thread.run(
+        "Do not use tools. Remember this exact token for the next turn: "
+        f"{remembered_value}. Reply with exactly READY and nothing else.",
+    )
+    thread_id = thread.id
+
+    assert first_turn.final_response.strip() == "READY"
+    assert thread_id is not None
+
+    resumed = client.resume_thread(
+        thread_id,
+        **_build_thread_options(real_model, real_working_directory),
+    )
+    second_turn = resumed.run(
+        "Do not use tools. Return the exact token I asked you to remember in the previous turn. "
+        "Reply with only the token.",
+    )
+
+    assert resumed.id == thread_id
+    assert second_turn.final_response.strip() == remembered_value
+
+
+def test_codex_run_returns_json_when_output_schema_is_provided(
+    real_model: str,
+    real_working_directory: Path,
+) -> None:
+    client = Codex()
+    thread = client.start_thread(**_build_thread_options(real_model, real_working_directory))
+    turn = thread.run(
+        'Do not use tools. Return only JSON with status "ok" and count 1.',
+        output_schema={
+            "type": "object",
+            "properties": {
+                "status": {"type": "string", "const": "ok"},
+                "count": {"type": "integer", "const": 1},
+            },
+            "required": ["status", "count"],
+            "additionalProperties": False,
+        },
+    )
+
+    assert turn.structured_response == {"status": "ok", "count": 1}
+
+
+def test_codex_run_streamed_yields_expected_events_and_result(
+    real_model: str,
+    real_working_directory: Path,
+) -> None:
+    response_marker = "ACODEX_SYNC_STREAM_OK"
+    client = Codex()
+    thread = client.start_thread(**_build_thread_options(real_model, real_working_directory))
+
+    streamed = thread.run_streamed(
+        f"Do not use tools. Reply with exactly {response_marker} and nothing else.",
+    )
+    events = list(streamed.events)
+    turn = streamed.result
+
+    assert any(isinstance(event, ThreadStartedEvent) for event in events)
+    assert any(isinstance(event, TurnStartedEvent) for event in events)
+    assert any(isinstance(event, ItemCompletedEvent) for event in events)
+    assert any(isinstance(event, TurnCompletedEvent) for event in events)
+    assert turn.items
+    assert turn.final_response.strip() == response_marker
+
+
+def test_async_codex_run_streamed_yields_parsed_events_end_to_end(
+    real_model: str,
+    real_working_directory: Path,
+) -> None:
+    response_marker = "ACODEX_ASYNC_STREAM_OK"
+
+    async def run() -> tuple[bool, bool, bool, bool, str, int]:
+        client = AsyncCodex()
+        thread = client.start_thread(**_build_thread_options(real_model, real_working_directory))
+        streamed = await thread.run_streamed(
+            f"Do not use tools. Reply with exactly {response_marker} and nothing else.",
+        )
+        events = [event async for event in streamed.events]
+        turn = streamed.result
+        return (
+            any(isinstance(event, ThreadStartedEvent) for event in events),
+            any(isinstance(event, TurnStartedEvent) for event in events),
+            any(isinstance(event, ItemCompletedEvent) for event in events),
+            any(isinstance(event, TurnCompletedEvent) for event in events),
+            turn.final_response.strip(),
+            len(turn.items),
+        )
+
+    (
+        has_thread_started,
+        has_turn_started,
+        has_item_completed,
+        has_turn_completed,
+        final_response,
+        item_count,
+    ) = asyncio.run(run())
+
+    assert has_thread_started
+    assert has_turn_started
+    assert has_item_completed
+    assert has_turn_completed
+    assert item_count > 0
+    assert final_response == response_marker
+
+
+def test_codex_run_returns_validated_pydantic_structured_output(
+    real_model: str,
+    real_working_directory: Path,
+) -> None:
+    try:
+        from pydantic import BaseModel
+    except ModuleNotFoundError as error:
+        if error.name in {"pydantic", "pydantic_core"}:
+            pytest.skip("Pydantic is not available in this interpreter.")
+        raise
+
+    class StructuredPayload(BaseModel):
+        status: Literal["ok"]
+        count: int
+
+    client = Codex()
+    thread = client.start_thread(**_build_thread_options(real_model, real_working_directory))
+    turn = thread.run(
+        'Do not use tools. Return only JSON with status "ok" and count 1.',
+        output_type=StructuredPayload,
+    )
+    payload = turn.structured_response
+
+    assert isinstance(payload, StructuredPayload)
+    assert payload.model_dump() == {"status": "ok", "count": 1}
+
+
+def _build_thread_options(real_model: str, real_working_directory: Path) -> ThreadOptions:
+    return ThreadOptions(
+        model=real_model,
+        sandbox_mode="read-only",
+        working_directory=str(real_working_directory),
+        skip_git_repo_check=True,
+        web_search_enabled=False,
+    )


### PR DESCRIPTION
## Summary
- add an opt-in `real_integration` pytest marker and a local `make test-real-integration` target for live SDK validation
- add an SDK-only real integration suite covering sync runs, resume, streaming, async streaming, and structured output
- keep paid real integration coverage out of the default test path and GitHub CI, and document the local opt-in workflow

## Why
The project needs a way to exercise the real local Codex setup for end-to-end SDK validation without making the default test path slower, paid, or CI-dependent.

## Developer Impact
Contributors can keep using `make test` as the CI-safe default, and can opt into the live suite locally with `ACODEX_RUN_REAL_INTEGRATION=1 make test-real-integration`. The live suite defaults to `ACODEX_REAL_MODEL=gpt-5.3-codex` and can be overridden when needed.

## Validation
- `make lint`
- `make test`
