### PR TITLE
tests: add complex structured output integration coverage

### DIFF
--- a/tests/integration/test_real_sdk.py
+++ b/tests/integration/test_real_sdk.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
+from enum import Enum
 from pathlib import Path
-from typing import Literal
+from typing import Generic, Literal, TypeVar
 
 import pytest
 
@@ -175,6 +177,198 @@ def test_codex_run_returns_validated_pydantic_structured_output(
 
     assert isinstance(payload, StructuredPayload)
     assert payload.model_dump() == {"status": "ok", "count": 1}
+
+
+def test_codex_run_returns_complex_validated_pydantic_structured_output(
+    real_model: str,
+    real_working_directory: Path,
+) -> None:
+    try:
+        from pydantic import BaseModel
+    except ModuleNotFoundError as error:
+        if error.name in {"pydantic", "pydantic_core"}:
+            pytest.skip("Pydantic is not available in this interpreter.")
+        raise
+
+    value_t = TypeVar("value_t")
+
+    class ReleaseType(str, Enum):
+        MAJOR = "major"
+        MINOR = "minor"
+        PATCH = "patch"
+
+    class ReleaseChannel(str, Enum):
+        STABLE = "stable"
+        BETA = "beta"
+        CANARY = "canary"
+
+    class ArtifactKind(str, Enum):
+        WHEEL = "wheel"
+        DOCS = "docs"
+        SBOM = "sbom"
+
+    class ApprovalStatus(str, Enum):
+        APPROVED = "approved"
+        PENDING = "pending"
+
+    class LabeledValue(BaseModel, Generic[value_t]):
+        label: str
+        value: value_t
+
+    class CollectionPage(BaseModel, Generic[value_t]):
+        total: int
+        items: list[value_t]
+
+    class ReleaseOwner(BaseModel):
+        team: str
+        primary_contact: str
+        escalation_contacts: list[str]
+
+    class ReleaseArtifact(BaseModel):
+        kind: ArtifactKind
+        name: str
+        checksum: str
+        mirrors: list[LabeledValue[str]]
+
+    class RolloutPhase(BaseModel):
+        name: str
+        audience_percent: int
+        metrics: list[LabeledValue[int]]
+
+    class ReleaseApproval(BaseModel):
+        reviewer: str
+        status: ApprovalStatus
+
+    class ReleaseRecord(BaseModel):
+        version: str
+        release_type: ReleaseType
+        channels: list[ReleaseChannel]
+        owner: ReleaseOwner
+        artifacts: CollectionPage[ReleaseArtifact]
+        rollout_phases: list[RolloutPhase]
+        approvals: list[ReleaseApproval]
+        metadata: dict[str, str]
+        highlights: list[str]
+
+    class ReleaseEnvelope(BaseModel):
+        status: Literal["ok"]
+        release: ReleaseRecord
+        related_versions: CollectionPage[LabeledValue[str]]
+        summary: str
+
+    expected_payload = {
+        "status": "ok",
+        "release": {
+            "version": "2.4.0",
+            "release_type": "minor",
+            "channels": ["stable", "beta"],
+            "owner": {
+                "team": "sdk-platform",
+                "primary_contact": "sdk@example.com",
+                "escalation_contacts": ["lead@example.com", "ops@example.com"],
+            },
+            "artifacts": {
+                "total": 3,
+                "items": [
+                    {
+                        "kind": "wheel",
+                        "name": "acodex-2.4.0-py3-none-any.whl",
+                        "checksum": "sha256:wheel-240",
+                        "mirrors": [
+                            {
+                                "label": "primary",
+                                "value": "https://example.com/downloads/acodex-2.4.0.whl",
+                            },
+                            {
+                                "label": "backup",
+                                "value": "https://mirror.example.com/acodex-2.4.0.whl",
+                            },
+                        ],
+                    },
+                    {
+                        "kind": "docs",
+                        "name": "acodex-2.4.0-docs.tar.gz",
+                        "checksum": "sha256:docs-240",
+                        "mirrors": [
+                            {
+                                "label": "primary",
+                                "value": "https://example.com/downloads/acodex-2.4.0-docs.tar.gz",
+                            },
+                        ],
+                    },
+                    {
+                        "kind": "sbom",
+                        "name": "acodex-2.4.0.spdx.json",
+                        "checksum": "sha256:sbom-240",
+                        "mirrors": [
+                            {
+                                "label": "primary",
+                                "value": "https://example.com/downloads/acodex-2.4.0.spdx.json",
+                            },
+                        ],
+                    },
+                ],
+            },
+            "rollout_phases": [
+                {
+                    "name": "pilot",
+                    "audience_percent": 10,
+                    "metrics": [
+                        {"label": "error_budget_remaining", "value": 99},
+                        {"label": "support_tickets", "value": 0},
+                    ],
+                },
+                {
+                    "name": "general",
+                    "audience_percent": 100,
+                    "metrics": [
+                        {"label": "error_budget_remaining", "value": 97},
+                        {"label": "support_tickets", "value": 3},
+                    ],
+                },
+            ],
+            "approvals": [
+                {"reviewer": "release-bot", "status": "approved"},
+                {"reviewer": "qa-lead", "status": "pending"},
+            ],
+            "metadata": {
+                "ticket": "REL-240",
+                "release_train": "2026.03",
+                "backward_compatible": "true",
+            },
+            "highlights": [
+                "Adds nested structured output coverage for the Python SDK.",
+                "Exercises enum validation and multiple generic container shapes.",
+            ],
+        },
+        "related_versions": {
+            "total": 2,
+            "items": [
+                {"label": "previous", "value": "2.3.1"},
+                {"label": "next_planned", "value": "2.5.0"},
+            ],
+        },
+        "summary": "Minor SDK release with staged rollout metadata.",
+    }
+
+    client = Codex()
+    thread = client.start_thread(**_build_thread_options(real_model, real_working_directory))
+    turn = thread.run(
+        "Do not use tools. Return only JSON that exactly matches this object. "
+        "Do not add markdown, code fences, or any explanation.\n"
+        f"{json.dumps(expected_payload, indent=2)}",
+        output_type=ReleaseEnvelope,
+    )
+    payload = turn.structured_response
+
+    assert isinstance(payload, ReleaseEnvelope)
+    assert payload.release.release_type is ReleaseType.MINOR
+    assert payload.release.channels == [ReleaseChannel.STABLE, ReleaseChannel.BETA]
+    assert payload.release.artifacts.items[0].kind is ArtifactKind.WHEEL
+    assert payload.release.artifacts.items[1].kind is ArtifactKind.DOCS
+    assert payload.release.approvals[0].status is ApprovalStatus.APPROVED
+    assert payload.release.approvals[1].status is ApprovalStatus.PENDING
+    assert payload.model_dump(mode="json") == expected_payload
 
 
 def _build_thread_options(real_model: str, real_working_directory: Path) -> ThreadOptions:


### PR DESCRIPTION
## Summary
- add a larger real integration test for `output_type` structured responses
- exercise nested Pydantic models, generic containers, enum fields, and full JSON round-trip assertions
- keep the existing small structured-output integration test intact while adding a heavier end-to-end case

## Why
This adds coverage for a more realistic structured response shape and makes it easier to catch schema-generation issues that only appear with richer nested models.

## Validation
- `make format`
- `make lint`
- `make test`
- `ACODEX_RUN_REAL_INTEGRATION=1 uv run pytest tests/integration/test_real_sdk.py -k complex_validated_pydantic_structured_output -vv` (fails)

## Live Integration Failure
The new real integration test currently fails before model output with an API schema validation error:

`invalid_json_schema`: `Invalid schema for response_format 'codex_output_schema': In context=(), 'required' is required to be supplied and to be an array including every key in properties. Extra required key 'metadata' supplied.`

This PR intentionally preserves that failing case for investigation rather than changing library behavior.