### PR TITLE
fix: refresh stale renderer assets

### DIFF
--- a/src/acodex/cli/tools/__init__.py
+++ b/src/acodex/cli/tools/__init__.py
@@ -5,7 +5,9 @@ from acodex.cli.tools.arguments import (
     JSONArgumentSource,
     OptionTokenParser,
     OptionTokenStream,
+    SchemaArgumentNormalizer,
     ToolArgumentsParser,
+    normalize_tool_arguments,
     parse_tool_arguments,
 )
 from acodex.cli.tools.client_provider import (
@@ -33,6 +35,7 @@ __all__ = (
     "ManagedMCPToolsClientProvider",
     "OptionTokenParser",
     "OptionTokenStream",
+    "SchemaArgumentNormalizer",
     "ServerManager",
     "ToolArgumentsError",
     "ToolArgumentsParser",
@@ -42,6 +45,7 @@ __all__ = (
     "find_tool_descriptor",
     "json_syntax",
     "mcp_tool_result_shape",
+    "normalize_tool_arguments",
     "panel",
     "parse_tool_arguments",
     "tool_output_note",

--- a/src/acodex/cli/tools/arguments.py
+++ b/src/acodex/cli/tools/arguments.py
@@ -11,6 +11,7 @@ from acodex.cli.tools.models import ToolArgumentsError
 ARGUMENT_KEY_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_-]*$")
 HELP_TOKEN = "--help"  # noqa: S105 - CLI help flag, not a password.
 OPTION_PREFIX = "--"
+PROPERTIES_KEY = "properties"
 
 
 @dataclass(frozen=True, slots=True)
@@ -177,3 +178,74 @@ def parse_tool_arguments(
     args_json_file: Path | None = None,
 ) -> dict[str, Any]:
     return ToolArgumentsParser().parse(tokens, args_json=args_json, args_json_file=args_json_file)
+
+
+@dataclass(frozen=True, slots=True)
+class SchemaArgumentNormalizer:
+    """Map CLI-friendly argument names onto JSON schema property names."""
+
+    def normalize(
+        self,
+        arguments: dict[str, Any],
+        *,
+        input_schema: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Return arguments with schema-backed camelCase aliases applied."""
+        properties = self._schema_properties(input_schema)
+        if not properties:
+            return arguments
+        aliases = self._property_aliases(properties)
+        normalized_arguments: dict[str, Any] = {}
+        for argument_key, argument_value in arguments.items():
+            normalized_key = self._normalized_key(
+                argument_key=argument_key,
+                properties=properties,
+                aliases=aliases,
+            )
+            if normalized_key in normalized_arguments:
+                raise ToolArgumentsError(f"Duplicate tool argument: {normalized_key}")
+            normalized_arguments[normalized_key] = argument_value
+        return normalized_arguments
+
+    def _schema_properties(self, input_schema: dict[str, Any] | None) -> dict[str, Any]:
+        if input_schema is None:
+            return {}
+        properties = input_schema.get(PROPERTIES_KEY)
+        if not isinstance(properties, dict):
+            return {}
+        return cast("dict[str, Any]", properties)
+
+    def _property_aliases(self, properties: dict[str, Any]) -> dict[str, str]:
+        aliases: dict[str, str] = {}
+        duplicate_signatures: set[str] = set()
+        for property_name in properties:
+            signature = self._argument_signature(property_name)
+            if signature in aliases:
+                duplicate_signatures.add(signature)
+            else:
+                aliases[signature] = property_name
+        for duplicate_signature in duplicate_signatures:
+            aliases.pop(duplicate_signature)
+        return aliases
+
+    def _normalized_key(
+        self,
+        *,
+        argument_key: str,
+        properties: dict[str, Any],
+        aliases: dict[str, str],
+    ) -> str:
+        if argument_key in properties:
+            return argument_key
+        return aliases.get(self._argument_signature(argument_key), argument_key)
+
+    def _argument_signature(self, argument_key: str) -> str:
+        return argument_key.replace("_", "").replace("-", "").lower()
+
+
+def normalize_tool_arguments(
+    arguments: dict[str, Any],
+    *,
+    input_schema: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return SchemaArgumentNormalizer().normalize(arguments, input_schema=input_schema)

--- a/src/acodex/cli/tools/command.py
+++ b/src/acodex/cli/tools/command.py
@@ -2,16 +2,18 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from diwire import Injected
 
-from acodex.cli.tools.arguments import ToolArgumentsParser
+from acodex.cli.tools.arguments import ToolArgumentsParser, normalize_tool_arguments
 from acodex.cli.tools.client_provider import ManagedMCPToolsClientProvider
+from acodex.cli.tools.descriptors import find_tool_descriptor
 from acodex.cli.tools.models import ToolOutput
 from acodex.cli.tools.presenter import ToolsPresenter
 
 IS_ERROR_KEY = "isError"
+INPUT_SCHEMA_KEY = "inputSchema"
 
 
 @dataclass(frozen=True, kw_only=True, slots=True)
@@ -55,6 +57,33 @@ class ToolsCommand:
             args_json=args_json,
             args_json_file=args_json_file,
         )
+        if self._may_need_schema_normalization(tool_arguments):
+            tool_arguments = self._normalize_arguments(
+                client.list_tools(),
+                name=name,
+                arguments=tool_arguments,
+            )
         tool_result: dict[str, Any] = client.call_tool(name, tool_arguments)
         self.presenter.tool_call_result(tool_result, output=output)
         return 1 if tool_result.get(IS_ERROR_KEY) is True else 0
+
+    def _may_need_schema_normalization(self, arguments: dict[str, Any]) -> bool:
+        return any("_" in argument_key or "-" in argument_key for argument_key in arguments)
+
+    def _normalize_arguments(
+        self,
+        tools: list[dict[str, Any]],
+        *,
+        name: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        descriptor_payload = find_tool_descriptor(tools, name)
+        if descriptor_payload is None:
+            return arguments
+        input_schema = descriptor_payload.get(INPUT_SCHEMA_KEY)
+        if not isinstance(input_schema, dict):
+            return arguments
+        return normalize_tool_arguments(
+            arguments,
+            input_schema=cast("dict[str, Any]", input_schema),
+        )

--- a/src/acodex/core/codex_app/bridge.py
+++ b/src/acodex/core/codex_app/bridge.py
@@ -17,6 +17,10 @@ from acodex.core.codex_app.runtime_dependencies import (
 
 APP_RESOURCE_URL_PREFIX = "app://-"
 DYNAMIC_IMPORT_FAILURE = "Failed to fetch dynamically imported module"
+INPUT_SCHEMA_KEY = "inputSchema"
+OBJECT_SCHEMA_TYPE = "object"
+PROPERTIES_KEY = "properties"
+TYPE_KEY = "type"
 
 
 class CodexAppBridgeSettings(BaseSettings):
@@ -48,7 +52,11 @@ class CodexAppBridge:
         if not isinstance(tools, list):
             return []
         tool_payloads = cast("list[Any]", tools)  # type: ignore[redundant-cast]
-        return [cast("dict[str, Any]", tool) for tool in tool_payloads if isinstance(tool, dict)]
+        return [
+            normalize_mcp_tool_descriptor(cast("dict[str, Any]", tool))
+            for tool in tool_payloads
+            if isinstance(tool, dict)
+        ]
 
     async def call_tool(
         self,
@@ -128,3 +136,25 @@ def normalize_tool_name(name: str) -> str:
     if name.startswith("codex_app__"):
         return name.removeprefix("codex_app__")
     return name
+
+
+def normalize_mcp_tool_descriptor(tool: dict[str, Any]) -> dict[str, Any]:
+    """Return a descriptor with an MCP Inspector-compatible input schema."""
+    return {
+        **tool,
+        INPUT_SCHEMA_KEY: normalize_mcp_input_schema(tool.get(INPUT_SCHEMA_KEY)),
+    }
+
+
+def normalize_mcp_input_schema(input_schema: Any) -> dict[str, Any]:
+    """Return an MCP-compatible object input schema."""
+    if not isinstance(input_schema, dict):
+        return {TYPE_KEY: OBJECT_SCHEMA_TYPE, PROPERTIES_KEY: {}}
+
+    schema = cast("dict[str, Any]", input_schema)
+    if schema.get(TYPE_KEY) == OBJECT_SCHEMA_TYPE:
+        return dict(schema)
+    return {
+        **schema,
+        TYPE_KEY: OBJECT_SCHEMA_TYPE,
+    }

--- a/src/acodex/core/codex_app/bridge.py
+++ b/src/acodex/core/codex_app/bridge.py
@@ -15,6 +15,9 @@ from acodex.core.codex_app.runtime_dependencies import (
     load_workspace_dependencies_fallback,
 )
 
+APP_RESOURCE_URL_PREFIX = "app://-"
+DYNAMIC_IMPORT_FAILURE = "Failed to fetch dynamically imported module"
+
 
 class CodexAppBridgeSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="ACODEX_CODEX_APP_BRIDGE_")
@@ -80,6 +83,15 @@ class CodexAppBridge:
         return tool_payload
 
     async def _evaluate(self, payload: dict[str, Any]) -> dict[str, Any]:
+        result_payload = await self._evaluate_once(payload)
+        if self._is_stale_asset_failure(result_payload):
+            self._assets = None
+            result_payload = await self._evaluate_once(payload)
+        if not result_payload.get("ok"):
+            raise CodexAppBridgeError(str(result_payload.get("error") or "Codex bridge failed"))
+        return result_payload
+
+    async def _evaluate_once(self, payload: dict[str, Any]) -> dict[str, Any]:
         assets = await self._get_assets()
         bridge_payload = {
             **payload,
@@ -92,10 +104,17 @@ class CodexAppBridge:
             result = json.loads(result)
         if not isinstance(result, dict):
             raise CodexAppBridgeError(f"Unexpected Codex bridge result: {result!r}")
-        result_payload = cast("dict[str, Any]", result)
-        if not result_payload.get("ok"):
-            raise CodexAppBridgeError(str(result_payload.get("error") or "Codex bridge failed"))
-        return result_payload
+        return cast("dict[str, Any]", result)
+
+    def _is_stale_asset_failure(self, result_payload: dict[str, Any]) -> bool:
+        if result_payload.get("ok"):
+            return False
+        error_message = result_payload.get("error")
+        return (
+            isinstance(error_message, str)
+            and DYNAMIC_IMPORT_FAILURE in error_message
+            and APP_RESOURCE_URL_PREFIX in error_message
+        )
 
     async def _get_assets(self) -> CodexRendererAssets:
         if self._assets is None:

--- a/src/acodex/core/codex_app/cdp/client.py
+++ b/src/acodex/core/codex_app/cdp/client.py
@@ -113,6 +113,7 @@ class CodexCDPClient:
 
             self._ws = await websockets.connect(
                 websocket_url,
+                max_size=None,
                 open_timeout=self._settings.request_timeout,
             )
             self._recv_task = asyncio.create_task(self._recv_loop())

--- a/src/acodex/core/codex_app/renderer_bridge.py
+++ b/src/acodex/core/codex_app/renderer_bridge.py
@@ -528,12 +528,13 @@ async function callRendererHandler(modules, config, toolName, args) {
   }
 
   const wantedNames = handlerProbeNames(toolName, descriptors);
+  const initialSourceThreadId = config.sourceThreadId || null;
   let handlerMap = await buildHandlerMapForNames(
     dynamicTools,
     manager,
     wantedNames,
     scope,
-    config.sourceThreadId
+    initialSourceThreadId
   );
   const sourceThreadId = await resolveSourceThreadId(
     toolName,
@@ -543,13 +544,15 @@ async function callRendererHandler(modules, config, toolName, args) {
     scope,
     handlerMap
   );
-  handlerMap = await buildHandlerMapForNames(
-    dynamicTools,
-    manager,
-    wantedNames,
-    scope,
-    sourceThreadId
-  );
+  if (sourceThreadId !== initialSourceThreadId) {
+    handlerMap = await buildHandlerMapForNames(
+      dynamicTools,
+      manager,
+      wantedNames,
+      scope,
+      sourceThreadId
+    );
+  }
   const handler = handlerMap.get(toolName);
   if (!handler) {
     return noHandler(toolName);

--- a/src/acodex/core/codex_app/renderer_bridge.py
+++ b/src/acodex/core/codex_app/renderer_bridge.py
@@ -121,20 +121,19 @@ function noHandler(toolName) {
         type: "inputText",
         text:
           `Codex exposed the ${toolName} descriptor, but this build did not export a callable renderer handler for it. ` +
-          `If the Electron MCP host implements call-mcp-tool in a newer build, this proxy will use it automatically.`,
+          `This proxy can call only live renderer handlers exported by the current Codex desktop build.`,
       },
     ],
   };
 }
 
 async function loadModules(config) {
-  const [dynamicTools, manager, appScope, vscodeApi] = await Promise.all([
+  const [dynamicTools, manager, appScope] = await Promise.all([
     import(config.assets.dynamicToolsUrl),
     import(config.assets.managerUrl),
     import(config.assets.appScopeUrl),
-    config.assets.vscodeApiUrl ? import(config.assets.vscodeApiUrl) : Promise.resolve(null),
   ]);
-  return { dynamicTools, manager, appScope, vscodeApi };
+  return { dynamicTools, manager, appScope };
 }
 
 function findScopeChain() {

--- a/src/acodex/core/codex_app/renderer_bridge.py
+++ b/src/acodex/core/codex_app/renderer_bridge.py
@@ -515,75 +515,6 @@ function hasAllHandlers(map, wantedNames) {
   return true;
 }
 
-async function findApiCall(vscodeApi) {
-  if (!vscodeApi) return null;
-  for (const fn of Object.values(vscodeApi)) {
-    if (typeof fn !== "function") continue;
-    const source = safeFunctionSource(fn);
-    if (source.includes("vscode://codex/") || source.includes("sendMessageFromView")) {
-      return fn;
-    }
-  }
-  for (const fn of Object.values(vscodeApi)) {
-    if (typeof fn !== "function") continue;
-    try {
-      const result = await fn("extension-info");
-      if (result && typeof result === "object") return fn;
-    } catch {
-      // Not the bridge function.
-    }
-  }
-  return null;
-}
-
-async function tryInternalMcpCall(vscodeApi, config, toolName, args, sourceThreadId) {
-  // Current desktop builds can leave this internal MCP call pending; use the live renderer handler.
-  if (toolName === "list_threads") {
-    return null;
-  }
-  const apiCall = await findApiCall(vscodeApi);
-  if (!apiCall) return null;
-  try {
-    const status = await apiCall("list-mcp-server-status", {
-      params: {
-        cursor: null,
-        detail: "toolsAndAuthOnly",
-        hostId: config.hostId,
-        limit: 100,
-      },
-    });
-    const servers = Array.isArray(status?.data)
-      ? status.data
-      : Array.isArray(status?.servers)
-        ? status.servers
-        : [];
-    const server = servers.find((candidate) => {
-      const name = candidate?.name || candidate?.serverName || candidate?.id;
-      return name === "codex_apps";
-    });
-    if (!server) return null;
-    const tools = server.tools || server.toolNames || [];
-    const toolNames = tools.map((tool) => (typeof tool === "string" ? tool : tool?.name)).filter(Boolean);
-    const internalToolName = toolNames.includes(toolName)
-      ? toolName
-      : toolNames.includes(`_${toolName}`)
-        ? `_${toolName}`
-        : null;
-    if (!internalToolName) return null;
-    return await apiCall("call-mcp-tool", {
-      params: {
-        arguments: args,
-        hostId: config.hostId,
-        server: "codex_apps",
-        threadId: sourceThreadId,
-        tool: internalToolName,
-      },
-    });
-  } catch {
-    return null;
-  }
-}
-
 async function callRendererHandler(modules, config, toolName, args) {
   const { dynamicTools, manager, appScope } = modules;
   const scope = makeScope(appScope);
@@ -666,17 +597,6 @@ async function runCodexAppMcpBridge(config) {
 
     const toolName = config.toolName;
     const args = config.arguments || {};
-    const internalResult = await tryInternalMcpCall(
-      modules.vscodeApi,
-      config,
-      toolName,
-      args,
-      config.sourceThreadId || args.threadId || null
-    );
-    if (internalResult != null) {
-      return asResult({ result: internalResult });
-    }
-
     const result = await callRendererHandler(modules, config, toolName, args);
     return asResult({ result });
   } catch (error) {

--- a/src/acodex/core/codex_app/renderer_bridge.py
+++ b/src/acodex/core/codex_app/renderer_bridge.py
@@ -345,7 +345,7 @@ async function listCodexDescriptors(dynamicTools, manager, hostId) {
 }
 
 function shouldProbeDynamicHandler(fn) {
-  const source = Function.prototype.toString.call(fn);
+  const source = safeFunctionSource(fn);
   return (
     source.includes("argumentsValue") ||
     source.includes("received invalid arguments") ||
@@ -354,12 +354,20 @@ function shouldProbeDynamicHandler(fn) {
 }
 
 function shouldProbeManagerHandler(fn) {
-  const source = Function.prototype.toString.call(fn);
+  const source = safeFunctionSource(fn);
   return (
     source.includes("takes no arguments") ||
     source.includes("read_thread_terminal") ||
     source.includes("load_workspace_dependencies")
   );
+}
+
+function safeFunctionSource(fn) {
+  try {
+    return Function.prototype.toString.call(fn);
+  } catch {
+    return "";
+  }
 }
 
 async function safeInvoke(fn, ...values) {
@@ -465,6 +473,10 @@ async function inferSourceThreadId(dynamicTools, scope, handlerMap, configuredSo
 
 async function buildHandlerMap(dynamicTools, manager, descriptors, scope, sourceThreadId) {
   const wantedNames = new Set(descriptors.map((descriptor) => descriptor.name));
+  return await buildHandlerMapForNames(dynamicTools, manager, wantedNames, scope, sourceThreadId);
+}
+
+async function buildHandlerMapForNames(dynamicTools, manager, wantedNames, scope, sourceThreadId) {
   const map = new Map();
   const probeArgs = { __codex_mcp_probe__: true };
 
@@ -477,6 +489,9 @@ async function buildHandlerMap(dynamicTools, manager, descriptors, scope, source
         map.set(name, { kind: "dynamic", fn });
       }
     }
+  }
+  if (hasAllHandlers(map, wantedNames)) {
+    return map;
   }
 
   for (const fn of Object.values(manager)) {
@@ -493,11 +508,18 @@ async function buildHandlerMap(dynamicTools, manager, descriptors, scope, source
   return map;
 }
 
+function hasAllHandlers(map, wantedNames) {
+  for (const name of wantedNames) {
+    if (!map.has(name)) return false;
+  }
+  return true;
+}
+
 async function findApiCall(vscodeApi) {
   if (!vscodeApi) return null;
   for (const fn of Object.values(vscodeApi)) {
     if (typeof fn !== "function") continue;
-    const source = Function.prototype.toString.call(fn);
+    const source = safeFunctionSource(fn);
     if (source.includes("vscode://codex/") || source.includes("sendMessageFromView")) {
       return fn;
     }
@@ -575,14 +597,29 @@ async function callRendererHandler(modules, config, toolName, args) {
     };
   }
 
-  let handlerMap = await buildHandlerMap(dynamicTools, manager, descriptors, scope, config.sourceThreadId);
-  const sourceThreadId = args?.threadId || await inferSourceThreadId(
+  const wantedNames = handlerProbeNames(toolName, descriptors);
+  let handlerMap = await buildHandlerMapForNames(
     dynamicTools,
+    manager,
+    wantedNames,
     scope,
-    handlerMap,
     config.sourceThreadId
   );
-  handlerMap = await buildHandlerMap(dynamicTools, manager, descriptors, scope, sourceThreadId);
+  const sourceThreadId = await resolveSourceThreadId(
+    toolName,
+    args,
+    config,
+    dynamicTools,
+    scope,
+    handlerMap
+  );
+  handlerMap = await buildHandlerMapForNames(
+    dynamicTools,
+    manager,
+    wantedNames,
+    scope,
+    sourceThreadId
+  );
   const handler = handlerMap.get(toolName);
   if (!handler) {
     return noHandler(toolName);
@@ -591,6 +628,21 @@ async function callRendererHandler(modules, config, toolName, args) {
     return await safeInvoke(handler.fn, args, sourceThreadId);
   }
   return await safeInvoke(handler.fn, makeCallContext(scope, args, sourceThreadId, appServerRegistry));
+}
+
+async function resolveSourceThreadId(toolName, args, config, dynamicTools, scope, handlerMap) {
+  if (args?.threadId || config.sourceThreadId) {
+    return args?.threadId || config.sourceThreadId;
+  }
+  if (toolName === "list_threads") {
+    return null;
+  }
+  return await inferSourceThreadId(dynamicTools, scope, handlerMap, null);
+}
+
+function handlerProbeNames(toolName, descriptors) {
+  const descriptorNames = new Set(descriptors.map((descriptor) => descriptor.name));
+  return new Set([toolName, "list_threads"].filter((name) => descriptorNames.has(name)));
 }
 
 async function runCodexAppMcpBridge(config) {

--- a/tests/test_cdp_units.py
+++ b/tests/test_cdp_units.py
@@ -256,9 +256,15 @@ def test_ensure_connected_uses_existing_or_connects(monkeypatch: pytest.MonkeyPa
 
         connected = IterableWebSocket([])
 
-        async def connect(url: str, *, open_timeout: float) -> IterableWebSocket:
+        async def connect(
+            url: str,
+            *,
+            max_size: int | None,
+            open_timeout: float,
+        ) -> IterableWebSocket:
             await asyncio.sleep(0)
             assert url == "ws://target"
+            assert max_size is None
             assert open_timeout == pytest.approx(0.1)
             return connected
 

--- a/tests/test_cli_main_units.py
+++ b/tests/test_cli_main_units.py
@@ -494,6 +494,59 @@ def test_tools_list_and_call_commands(monkeypatch: pytest.MonkeyPatch) -> None:
     output_arg_call = cast("Any", FakeToolsClient.calls[-1])
     assert output_arg_call == ("codex_app.echo", {"output": "json"})
 
+    FakeToolsClient.tools = [
+        {
+            "name": "codex_app.send_message_to_thread",
+            "description": "Send a message.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "threadId": {"type": "string"},
+                    "prompt": {"type": "string"},
+                },
+            },
+        },
+    ]
+    assert (
+        runner.invoke(
+            cli.app,
+            [
+                "tools",
+                "call",
+                "codex_app.send_message_to_thread",
+                "--thread_id",
+                "thread-1",
+                "--prompt",
+                "hi",
+            ],
+        ).exit_code
+        == 0
+    )
+    assert cast("Any", FakeToolsClient.calls[-1]) == (
+        "codex_app.send_message_to_thread",
+        {"threadId": "thread-1", "prompt": "hi"},
+    )
+
+    FakeToolsClient.tools = []
+    assert (
+        runner.invoke(
+            cli.app,
+            ["tools", "call", "codex_app.echo", "--some_arg", "1"],
+        ).exit_code
+        == 0
+    )
+    assert cast("Any", FakeToolsClient.calls[-1]) == ("codex_app.echo", {"some_arg": 1})
+
+    FakeToolsClient.tools = [{"name": "codex_app.echo", "description": "Echo."}]
+    assert (
+        runner.invoke(
+            cli.app,
+            ["tools", "call", "codex_app.echo", "--some_arg", "2"],
+        ).exit_code
+        == 0
+    )
+    assert cast("Any", FakeToolsClient.calls[-1]) == ("codex_app.echo", {"some_arg": 2})
+
 
 def test_tools_call_tool_help(monkeypatch: pytest.MonkeyPatch) -> None:
     class ToolsServerManager:

--- a/tests/test_cli_tools_units.py
+++ b/tests/test_cli_tools_units.py
@@ -5,7 +5,7 @@ from pathlib import Path
 
 import pytest
 
-from acodex.cli.tools import ToolArgumentsError, parse_tool_arguments
+from acodex.cli.tools import ToolArgumentsError, normalize_tool_arguments, parse_tool_arguments
 
 
 def test_parse_tool_arguments_from_long_options() -> None:
@@ -72,3 +72,65 @@ def test_parse_tool_arguments_reports_invalid_input(
 def test_parse_tool_arguments_reports_unreadable_file(tmp_path: Path) -> None:
     with pytest.raises(ToolArgumentsError, match="Could not read tool arguments"):
         parse_tool_arguments([], args_json_file=tmp_path)
+
+
+def test_normalize_tool_arguments_maps_cli_aliases_to_schema_properties() -> None:
+    assert normalize_tool_arguments(
+        {
+            "thread_id": "thread-1",
+            "host-id": "local",
+            "prompt": "hi",
+        },
+        input_schema={
+            "type": "object",
+            "properties": {
+                "threadId": {"type": "string"},
+                "hostId": {"type": "string"},
+                "prompt": {"type": "string"},
+            },
+        },
+    ) == {
+        "threadId": "thread-1",
+        "hostId": "local",
+        "prompt": "hi",
+    }
+
+
+def test_normalize_tool_arguments_without_schema_properties_returns_original() -> None:
+    arguments = {"thread_id": "thread-1"}
+
+    assert normalize_tool_arguments(arguments, input_schema=None) is arguments
+    assert normalize_tool_arguments(arguments, input_schema={"properties": []}) is arguments
+
+
+def test_normalize_tool_arguments_preserves_unknown_and_ambiguous_keys() -> None:
+    assert normalize_tool_arguments(
+        {
+            "thread_id": "thread-1",
+            "unknown_value": True,
+        },
+        input_schema={
+            "properties": {
+                "threadId": {"type": "string"},
+                "threadid": {"type": "string"},
+            },
+        },
+    ) == {
+        "thread_id": "thread-1",
+        "unknown_value": True,
+    }
+
+
+def test_normalize_tool_arguments_reports_duplicate_schema_property() -> None:
+    with pytest.raises(ToolArgumentsError, match="Duplicate tool argument: threadId"):
+        normalize_tool_arguments(
+            {
+                "threadId": "thread-1",
+                "thread_id": "thread-2",
+            },
+            input_schema={
+                "properties": {
+                    "threadId": {"type": "string"},
+                },
+            },
+        )

--- a/tests/test_codex_app_units.py
+++ b/tests/test_codex_app_units.py
@@ -336,6 +336,27 @@ def test_tool_name_normalization_and_renderer_expression() -> None:
     assert "runCodexAppMcpBridge" in expression
 
 
+def test_renderer_bridge_guards_function_source_probe_failures() -> None:
+    assert "function safeFunctionSource(fn)" in BRIDGE_SCRIPT
+    assert 'catch {\n    return "";' in BRIDGE_SCRIPT
+    assert BRIDGE_SCRIPT.count("Function.prototype.toString.call") == 1
+    assert "const source = safeFunctionSource(fn);" in BRIDGE_SCRIPT
+
+
+def test_renderer_bridge_probes_only_needed_handlers_for_tool_calls() -> None:
+    assert "function handlerProbeNames(toolName, descriptors)" in BRIDGE_SCRIPT
+    assert 'new Set([toolName, "list_threads"].filter' in BRIDGE_SCRIPT
+    assert "await buildHandlerMapForNames(\n    dynamicTools," in BRIDGE_SCRIPT
+
+
+def test_renderer_bridge_does_not_infer_source_thread_for_list_threads() -> None:
+    assert (
+        "function resolveSourceThreadId(toolName, args, config, dynamicTools, scope, handlerMap)"
+        in (BRIDGE_SCRIPT)
+    )
+    assert 'if (toolName === "list_threads") {\n    return null;' in BRIDGE_SCRIPT
+
+
 def test_runtime_dependency_helpers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     assert not runtime_dependencies.is_descriptor_without_handler({"success": True})
     assert not runtime_dependencies.is_descriptor_without_handler(

--- a/tests/test_codex_app_units.py
+++ b/tests/test_codex_app_units.py
@@ -357,6 +357,14 @@ def test_renderer_bridge_does_not_infer_source_thread_for_list_threads() -> None
     assert 'if (toolName === "list_threads") {\n    return null;' in BRIDGE_SCRIPT
 
 
+def test_renderer_bridge_uses_live_handlers_instead_of_internal_mcp_calls() -> None:
+    assert "list-mcp-server-status" not in BRIDGE_SCRIPT
+    assert '"call-mcp-tool"' not in BRIDGE_SCRIPT
+    assert "const result = await callRendererHandler(modules, config, toolName, args);" in (
+        BRIDGE_SCRIPT
+    )
+
+
 def test_runtime_dependency_helpers(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     assert not runtime_dependencies.is_descriptor_without_handler({"success": True})
     assert not runtime_dependencies.is_descriptor_without_handler(

--- a/tests/test_codex_app_units.py
+++ b/tests/test_codex_app_units.py
@@ -349,6 +349,12 @@ def test_renderer_bridge_probes_only_needed_handlers_for_tool_calls() -> None:
     assert "await buildHandlerMapForNames(\n    dynamicTools," in BRIDGE_SCRIPT
 
 
+def test_renderer_bridge_skips_duplicate_source_thread_probe() -> None:
+    assert "const initialSourceThreadId = config.sourceThreadId || null;" in BRIDGE_SCRIPT
+    assert "if (sourceThreadId !== initialSourceThreadId) {" in BRIDGE_SCRIPT
+    assert "sourceThreadId\n    );\n  }" in BRIDGE_SCRIPT
+
+
 def test_renderer_bridge_does_not_infer_source_thread_for_list_threads() -> None:
     assert (
         "function resolveSourceThreadId(toolName, args, config, dynamicTools, scope, handlerMap)"

--- a/tests/test_codex_app_units.py
+++ b/tests/test_codex_app_units.py
@@ -360,6 +360,8 @@ def test_renderer_bridge_does_not_infer_source_thread_for_list_threads() -> None
 def test_renderer_bridge_uses_live_handlers_instead_of_internal_mcp_calls() -> None:
     assert "list-mcp-server-status" not in BRIDGE_SCRIPT
     assert '"call-mcp-tool"' not in BRIDGE_SCRIPT
+    assert "vscodeApiUrl ? import" not in BRIDGE_SCRIPT
+    assert "This proxy can call only live renderer handlers" in BRIDGE_SCRIPT
     assert "const result = await callRendererHandler(modules, config, toolName, args);" in (
         BRIDGE_SCRIPT
     )

--- a/tests/test_codex_app_units.py
+++ b/tests/test_codex_app_units.py
@@ -35,10 +35,12 @@ class FakeCDP:
         tree: dict[str, Any] | None = None,
         contents: dict[str, str | BaseException] | None = None,
         evaluate_result: Any = None,
+        evaluate_results: list[Any] | None = None,
     ) -> None:
         self.tree = tree or {}
         self.contents = contents or {}
         self.evaluate_result = evaluate_result
+        self.evaluate_results = evaluate_results or []
         self.evaluations: list[tuple[str, bool]] = []
 
     async def resource_tree(self) -> dict[str, Any]:
@@ -52,6 +54,8 @@ class FakeCDP:
 
     async def evaluate(self, expression: str, *, await_promise: bool = True) -> Any:
         self.evaluations.append((expression, await_promise))
+        if self.evaluate_results:
+            return self.evaluate_results.pop(0)
         return self.evaluate_result
 
 
@@ -241,6 +245,41 @@ def test_bridge_lists_and_calls_tools(monkeypatch: pytest.MonkeyPatch) -> None:
     assert await_promise is True
     assert '"toolName": "echo"' in expression
     assert '"sourceThreadId": "thread"' in expression
+
+
+def test_bridge_rediscovers_assets_after_stale_import_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cdp = FakeCDP(
+        evaluate_results=[
+            {
+                "ok": False,
+                "error": (
+                    "TypeError: Failed to fetch dynamically imported module: app://-/assets/old.js"
+                ),
+            },
+            {"ok": True, "tools": [{"name": "codex_app.echo"}]},
+        ],
+    )
+    discovered_assets = [
+        CodexRendererAssets("scope-1", "dynamic-1", "manager-1", None),
+        CodexRendererAssets("scope-2", "dynamic-2", "manager-2", "vscode-2"),
+    ]
+
+    async def discover(_cdp: CodexCDPClient) -> CodexRendererAssets:
+        await asyncio.sleep(0)
+        return discovered_assets.pop(0)
+
+    monkeypatch.setattr(bridge, "discover_renderer_assets", discover)
+    app_bridge = CodexAppBridge(
+        _cdp=cast("CodexCDPClient", cdp),
+        _settings=CodexAppBridgeSettings(),
+    )
+
+    assert run(app_bridge.list_tools()) == [{"name": "codex_app.echo"}]
+    assert len(cdp.evaluations) == 2
+    assert '"dynamicToolsUrl": "dynamic-1"' in cdp.evaluations[0][0]
+    assert '"dynamicToolsUrl": "dynamic-2"' in cdp.evaluations[1][0]
 
 
 def test_bridge_handles_invalid_results_and_workspace_fallback(

--- a/tests/test_codex_app_units.py
+++ b/tests/test_codex_app_units.py
@@ -213,7 +213,13 @@ def test_bridge_lists_and_calls_tools(monkeypatch: pytest.MonkeyPatch) -> None:
         evaluate_result=json.dumps(
             {
                 "ok": True,
-                "tools": [{"name": "codex_app.echo"}, "bad"],
+                "tools": [
+                    {
+                        "name": "codex_app.echo",
+                        "inputSchema": {"oneOf": [{"type": "object"}]},
+                    },
+                    "bad",
+                ],
                 "result": {"contentItems": [{"type": "inputText", "text": "ok"}]},
             },
         ),
@@ -236,7 +242,15 @@ def test_bridge_lists_and_calls_tools(monkeypatch: pytest.MonkeyPatch) -> None:
         _settings=CodexAppBridgeSettings(host_id="host", source_thread_id="thread"),
     )
 
-    assert run(app_bridge.list_tools()) == [{"name": "codex_app.echo"}]
+    assert run(app_bridge.list_tools()) == [
+        {
+            "name": "codex_app.echo",
+            "inputSchema": {
+                "oneOf": [{"type": "object"}],
+                "type": "object",
+            },
+        },
+    ]
     assert run(app_bridge.call_tool("codex_app__echo", {"value": 1})) == {
         "contentItems": [{"type": "inputText", "text": "ok"}],
     }
@@ -276,7 +290,12 @@ def test_bridge_rediscovers_assets_after_stale_import_failure(
         _settings=CodexAppBridgeSettings(),
     )
 
-    assert run(app_bridge.list_tools()) == [{"name": "codex_app.echo"}]
+    assert run(app_bridge.list_tools()) == [
+        {
+            "name": "codex_app.echo",
+            "inputSchema": {"type": "object", "properties": {}},
+        },
+    ]
     assert len(cdp.evaluations) == 2
     assert '"dynamicToolsUrl": "dynamic-1"' in cdp.evaluations[0][0]
     assert '"dynamicToolsUrl": "dynamic-2"' in cdp.evaluations[1][0]
@@ -334,6 +353,17 @@ def test_tool_name_normalization_and_renderer_expression() -> None:
     assert '"action": "listTools"' in expression
     assert "descriptorFactoryArgs" in BRIDGE_SCRIPT
     assert "runCodexAppMcpBridge" in expression
+
+
+def test_mcp_input_schema_normalization() -> None:
+    assert bridge.normalize_mcp_input_schema(None) == {
+        "type": "object",
+        "properties": {},
+    }
+    assert bridge.normalize_mcp_input_schema({"type": "object", "properties": {"x": {}}}) == {
+        "type": "object",
+        "properties": {"x": {}},
+    }
 
 
 def test_renderer_bridge_guards_function_source_probe_failures() -> None:

--- a/tests/test_mcp_list_threads_e2e.py
+++ b/tests/test_mcp_list_threads_e2e.py
@@ -98,6 +98,7 @@ def test_mcp_tools_list_returns_live_read_only_tools(mcp_endpoint: str) -> None:
     tools = _tools_from_response(tools_response)
     tool_names = {tool["name"] for tool in tools if isinstance(tool.get("name"), str)}
     assert tool_names >= _READ_ONLY_TOOL_NAMES
+    assert all(tool["inputSchema"]["type"] == "object" for tool in tools)
 
 
 def test_mcp_tools_call_read_only_tools(mcp_endpoint: str) -> None:

--- a/tests/test_mcp_list_threads_e2e.py
+++ b/tests/test_mcp_list_threads_e2e.py
@@ -15,6 +15,7 @@ import uvicorn
 
 from acodex.core.codex_app.cdp import CodexCDPSettings
 from acodex.http.app import app
+from acodex.http.mcp.constants import MCP_PROTOCOL_VERSION
 
 pytestmark = [
     pytest.mark.real_integration,
@@ -25,6 +26,16 @@ pytestmark = [
 
 _ENABLE_ENV = "ACODEX_RUN_REAL_INTEGRATION"
 _LOCAL_HOST = "127.0.0.1"
+_LIST_PROJECTS_TOOL = "codex_app.list_projects"
+_LIST_THREADS_TOOL = "codex_app.list_threads"
+_READ_THREAD_TOOL = "codex_app.read_thread"
+_WORKSPACE_DEPENDENCIES_TOOL = "codex_app.load_workspace_dependencies"
+_READ_ONLY_TOOL_NAMES = frozenset((
+    _LIST_PROJECTS_TOOL,
+    _LIST_THREADS_TOOL,
+    _READ_THREAD_TOOL,
+    _WORKSPACE_DEPENDENCIES_TOOL,
+))
 
 
 @pytest.fixture(scope="module")
@@ -64,53 +75,76 @@ def mcp_endpoint() -> Iterator[str]:
             pytest.fail("Uvicorn MCP test server did not stop")
 
 
-def test_mcp_tools_call_list_threads_returns_live_threads(mcp_endpoint: str) -> None:
+def test_mcp_tools_list_returns_live_read_only_tools(mcp_endpoint: str) -> None:
+    initialize_response = _post_jsonrpc(
+        mcp_endpoint,
+        _jsonrpc_request(
+            "initialize",
+            request_id="initialize",
+            params={
+                "protocolVersion": MCP_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "acodex-e2e", "version": "0"},
+            },
+        ),
+    )
+    initialize_result = _response_result(initialize_response)
+    assert initialize_result["protocolVersion"] == MCP_PROTOCOL_VERSION
+
     tools_response = _post_jsonrpc(
         mcp_endpoint,
-        {
-            "jsonrpc": "2.0",
-            "id": "tools-list",
-            "method": "tools/list",
-        },
+        _jsonrpc_request("tools/list", request_id="tools-list"),
     )
-    assert "error" not in tools_response, tools_response
-    tools = tools_response["result"]["tools"]
-    assert any(tool.get("name") == "codex_app.list_threads" for tool in tools)
+    tools = _tools_from_response(tools_response)
+    tool_names = {tool["name"] for tool in tools if isinstance(tool.get("name"), str)}
+    assert tool_names >= _READ_ONLY_TOOL_NAMES
 
-    call_response = _post_jsonrpc(
+
+def test_mcp_tools_call_read_only_tools(mcp_endpoint: str) -> None:
+    list_threads_payload = _json_tool_payload(
         mcp_endpoint,
-        {
-            "jsonrpc": "2.0",
-            "id": "list-threads",
-            "method": "tools/call",
-            "params": {
-                "name": "codex_app.list_threads",
-                "arguments": {"limit": 1},
-            },
-        },
+        name=_LIST_THREADS_TOOL,
+        arguments={"limit": 1},
     )
+    assert list_threads_payload["schemaVersion"] == 1
+    assert list_threads_payload["query"] is None
+    assert isinstance(list_threads_payload["threads"], list)
+    assert list_threads_payload["threads"], "live Codex list_threads returned no threads"
 
-    assert "error" not in call_response, call_response
-    result = call_response["result"]
-    assert result["isError"] is False
-
-    text = "\n".join(
-        item["text"]
-        for item in result["content"]
-        if item.get("type") == "text" and isinstance(item.get("text"), str)
-    )
-    payload = json.loads(text)
-
-    assert payload["schemaVersion"] == 1
-    assert payload["query"] is None
-    assert isinstance(payload["threads"], list)
-    assert payload["threads"], "live Codex list_threads returned no threads"
-
-    thread = payload["threads"][0]
+    thread = list_threads_payload["threads"][0]
     assert isinstance(thread["id"], str)
     assert thread["id"]
     assert isinstance(thread["hostId"], str)
     assert isinstance(thread["title"], str)
+
+    list_projects_payload = _json_tool_payload(
+        mcp_endpoint,
+        name=_LIST_PROJECTS_TOOL,
+        arguments={},
+    )
+    assert list_projects_payload["schemaVersion"] == 1
+    assert isinstance(list_projects_payload["projects"], list)
+
+    workspace_text = _tool_text(
+        mcp_endpoint,
+        name=_WORKSPACE_DEPENDENCIES_TOOL,
+        arguments={},
+    )
+    assert "Workspace dependencies" in workspace_text
+
+    read_thread_payload = _json_tool_payload(
+        mcp_endpoint,
+        name=_READ_THREAD_TOOL,
+        arguments={
+            "threadId": thread["id"],
+            "hostId": thread["hostId"],
+            "turnLimit": 1,
+            "includeOutputs": False,
+        },
+    )
+    assert read_thread_payload["schemaVersion"] == 1
+    assert read_thread_payload["thread"]["id"] == thread["id"]
+    assert isinstance(read_thread_payload["turns"], list)
 
 
 def _skip_unless_real_integration_enabled() -> None:
@@ -150,6 +184,22 @@ def _get_json(url: str, *, timeout: float) -> Any:
         return json.loads(response.read().decode("utf-8"))
 
 
+def _jsonrpc_request(
+    method: str,
+    *,
+    request_id: str,
+    params: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": method,
+    }
+    if params is not None:
+        payload["params"] = params
+    return payload
+
+
 def _post_jsonrpc(url: str, payload: dict[str, Any]) -> dict[str, Any]:
     request = urllib.request.Request(  # noqa: S310
         url,
@@ -164,3 +214,68 @@ def _post_jsonrpc(url: str, payload: dict[str, Any]) -> dict[str, Any]:
         result = json.loads(response.read().decode("utf-8"))
     assert isinstance(result, dict)
     return result
+
+
+def _response_result(response: dict[str, Any]) -> dict[str, Any]:
+    assert "error" not in response, response
+    result = response["result"]
+    assert isinstance(result, dict)
+    return result
+
+
+def _tools_from_response(response: dict[str, Any]) -> list[dict[str, Any]]:
+    result = _response_result(response)
+    tools = result["tools"]
+    assert isinstance(tools, list)
+    assert all(isinstance(tool, dict) for tool in tools)
+    return tools
+
+
+def _tool_result(
+    url: str,
+    *,
+    name: str,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    response = _post_jsonrpc(
+        url,
+        _jsonrpc_request(
+            "tools/call",
+            request_id=name,
+            params={
+                "name": name,
+                "arguments": arguments,
+            },
+        ),
+    )
+    result = _response_result(response)
+    assert result["isError"] is False, result
+    return result
+
+
+def _tool_text(url: str, *, name: str, arguments: dict[str, Any]) -> str:
+    result = _tool_result(url, name=name, arguments=arguments)
+    content = result["content"]
+    assert isinstance(content, list)
+    texts = [
+        item["text"]
+        for item in content
+        if (
+            isinstance(item, dict)
+            and item.get("type") == "text"
+            and isinstance(item.get("text"), str)
+        )
+    ]
+    assert texts, result
+    return "\n".join(texts)
+
+
+def _json_tool_payload(
+    url: str,
+    *,
+    name: str,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    payload = json.loads(_tool_text(url, name=name, arguments=arguments))
+    assert isinstance(payload, dict)
+    return payload


### PR DESCRIPTION
## What changed

- Retry Codex app bridge evaluation once when a cached renderer asset URL fails with `Failed to fetch dynamically imported module` for an `app://-` asset.
- Clear cached renderer asset discovery before the retry so the bridge uses the currently loaded Codex bundles.
- Added a regression test for stale dynamic import asset recovery.

## Root cause

The bridge cached discovered Codex renderer bundle URLs for the server process lifetime. After the Codex app loaded a newer renderer bundle, the cached `app://-/assets/app-server-dynamic-tools-*.js` URL could become stale, causing `acodex tools list` to fail during dynamic import.

## Validation

- `acodex tools list`
- Live stale-cache probe using `app://-/assets/app-server-dynamic-tools-Gzn-GJ0M.js`
- `uv run pytest tests/test_codex_app_units.py`
- `make test`
- `make lint`
- `uv run prek run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CLI tool arguments now automatically align with tool schemas, making commands with dashed or underscored options work more reliably.
  * Tool invocations now better support schema-driven inputs such as thread IDs and prompts.

* **Bug Fixes**
  * Improved recovery when app assets fail to load, with an automatic retry to help restore functionality.
  * Tool calls now route through the live renderer path more consistently, reducing failures in some app actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->